### PR TITLE
Fix null on .show() android

### DIFF
--- a/mapbox.android.js
+++ b/mapbox.android.js
@@ -171,10 +171,10 @@ mapbox.show = function(arg) {
       // TODO see https://github.com/mapbox/mapbox-gl-native/issues/4216
       // mapbox.mapView.setZoomLevel(settings.zoomLevel);
 
-      var activity = application.android.foregroundActivity;
-      var mapViewLayout = new android.widget.FrameLayout(activity);
+      var context = application.android.currentContext;
+      var mapViewLayout = new android.widget.FrameLayout(context);
       mapViewLayout.addView(mapbox.mapView);
-      topMostFrame.currentPage.android.getParent().addView(mapViewLayout);
+      topMostFrame.currentPage.android.addView(mapViewLayout);
     } catch (ex) {
       console.log("Error in mapbox.show: " + ex);
       reject(ex);


### PR DESCRIPTION
- FrameLayout constructor fixed with context not activity.
- getParent() returns null, the `android` prop on the `currentPage` is enough for _addView()_ on the _ViewGroup_

These changes work locally, still working on a minor issue with the map not rendering until the device screen goes to sleep and then when I wake the screen the map shows and the `.show().then()` executes.
