### PR TITLE
Improve the addPolyline color option

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Draw a polyline. Connect the points given as parameters.
   // Draw a two segment line near Amsterdam Central Station
   mapbox.addPolyline({
       id: 1, // optional, can be used in 'removePolylines'
-      color: 0xff29a025, //Set the color of the line (default black)
+      color: '#336699', // Set the color of the line (default black)
       width: 7, //Set the width of the line (default 5)
       points: [
           {

--- a/mapbox.android.js
+++ b/mapbox.android.js
@@ -2,6 +2,7 @@ var utils = require("utils/utils");
 var application = require("application");
 var frame = require("ui/frame");
 var fs = require("file-system");
+var Color = require("color").Color;
 var mapbox = require("./mapbox-common");
 mapbox._markers = [];
 mapbox._polylines = [];
@@ -606,7 +607,16 @@ mapbox.addPolyline = function (arg, nativeMap) {
 
       var polylineOptions = new com.mapbox.mapboxsdk.annotations.PolylineOptions();
       polylineOptions.width(arg.width || 5); // default 5
-      polylineOptions.color(arg.color || 0xff000000); // default black
+      
+      // Create android color && default black
+      var androidColor;
+      if (arg.color && Color.isValid(arg.color)) {
+          androidColor = arg.color ? new Color(arg.color).android : new Color('#000').android;
+      } else {
+        androidColor = new Color('#000').android;
+      }
+      
+      polylineOptions.color(androidColor);
       for (var p in points) {
         var point = points[p];
         polylineOptions.add(new com.mapbox.mapboxsdk.geometry.LatLng(point.lat, point.lng));

--- a/mapbox.d.ts
+++ b/mapbox.d.ts
@@ -32,9 +32,9 @@ declare module "nativescript-mapbox" {
        */
       width?: number;
       /**
-       * Color of the lone, default black (0xff000000).
+       * Color of the line, default black.
        */
-      color?: any;
+      color?: string;
       points: LatLng[];
     }
 


### PR DESCRIPTION
Use the NS `Color` module to simplify setting the `color` of the polyLine.
