### PR TITLE
Markers not cleaned from cache on android

### DIFF
--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -345,6 +345,15 @@ const _removeMarkers = (ids, nativeMap?) => {
       }
     }
   }
+  // remove markers from cache
+  if(ids){
+      _markers = _markers.filter((marker) => {
+          return ids.indexOf(marker.id) < 0;
+      });
+  }
+  else{
+      _markers = [];
+  }
 };
 
 const _getRegionName = (offlineRegion) => {


### PR DESCRIPTION
While the iOS version of "removeMarkers" command removes the markers from the cache, the android implementation seems to not do so.  This fix should properly remove markers from the cache whether all of them (if no id array is provided, or just the specified ids).