### PR TITLE
Allow Mapbox to load local json map style definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ All currently supported options for your XML based map are (__don't__ use other 
 |---|---|---
 |`accesstoken`|-|see 'Prerequisites' above
 |`delay`|0|A delay in milliseconds - you can set this to have better control over when Mapbox is invoked so it won't clash with other computations your app may need to perform.
-|`mapStyle`|streets|streets, light, dark, satellite_streets, satellite, traffic_day, traffic_night
+|`mapStyle`|streets|streets, light, dark, satellite_streets, satellite, traffic_day, traffic_night, an URL starting with mapbox:// or pointing to a custom JSON definition (http://, https://, or local relative to nativescript app path ~/) 
 |`latitude `|-|Set the center of the map by passing this in
 |`longitude`|-|.. and this as well
 |`zoomLevel`|0|0-20

--- a/demo/app/OSM-map-style.json
+++ b/demo/app/OSM-map-style.json
@@ -1,0 +1,30 @@
+{
+    "version": 8,
+    "name": "OpenStreetMap Tiles",
+    "sources": {
+        "OSMTileLayer": {
+            "type": "raster",
+            "attribution": "(c) OpenStreetMap contributors, CC-BY-SA",
+            "scheme": "xyz",
+            "tiles": [
+                "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                "https://b.tile.openstreetmap.org/{z}/{x}/{y}.png",
+                "https://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            ],
+            "minzoom": 0,
+            "maxzoom": 18,
+            "tileSize": 256,
+            "bounds": [ -180, -85, 180, 85 ]
+        }
+    },
+    "layers": [
+        {
+            "id": "OSMTileLayer",
+            "type": "raster",
+            "source": "OSMTileLayer",
+            "paint": {
+                "raster-fade-duration": 100
+            }
+        }
+    ]
+}

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -33,7 +33,7 @@ function onMapReady(args) {
   // map.setOnScrollListener((point?: LatLng) => console.log(`Map scrolled: ${JSON.stringify(point)}`));
 
   // this allows json style loading for XYZ or TMS tiles source
-  // map.setMapStyle("~/OSM-raster-style.json");
+  // map.setMapStyle("~/OSM-map-style.json");
 
   // .. or use the convenience methods exposed on args.map, for instance:
   map.addMarkers([

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -32,6 +32,9 @@ function onMapReady(args) {
   // this works perfectly fine, but generates a lot of noise
   // map.setOnScrollListener((point?: LatLng) => console.log(`Map scrolled: ${JSON.stringify(point)}`));
 
+  // this allows json style loading for XYZ or TMS tiles source
+  // map.setMapStyle("~/OSM-raster-style.json");
+
   // .. or use the convenience methods exposed on args.map, for instance:
   map.addMarkers([
     {

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -143,9 +143,9 @@ const _getMapStyle = (input: any): any => {
   // allow for a style URL to be passed
   if (/^mapbox:\/\/styles/.test(input) || /^http:\/\//.test(input) || /^https:\/\//.test(input)) {
     return input;
-  } else if (/^assets:\/\//.test(input)) {
-    let assetsPath = 'asset://app/assets/';
-    input = input.replace('assets://', assetsPath);
+  } else if (/^~\//.test(input)) {
+    let assetsPath = 'asset://app/';
+    input = input.replace(/^~\//, assetsPath);
     return input;
   } else if (input === MapStyle.LIGHT || input === MapStyle.LIGHT.toString()) {
     return Style.LIGHT;

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -141,13 +141,9 @@ export class MapboxView extends MapboxViewBase {
 const _getMapStyle = (input: any): any => {
   const Style = com.mapbox.mapboxsdk.constants.Style;
   // allow for a style URL to be passed
-  if (/^mapbox:\/\/styles/.test(input)) {
+  if (/^mapbox:\/\/styles/.test(input) || /^http:\/\//.test(input) || /^https:\/\//.test(input) || /^file:\/\//.test(input)) {
     return input;
-  }
-  if (/^http:\/\//.test(input) || /^https:\/\//.test(input) || /^file:\/\//.test(input)) {
-    return input;
-  }
-  if (input === MapStyle.LIGHT || input === MapStyle.LIGHT.toString()) {
+  } else if (input === MapStyle.LIGHT || input === MapStyle.LIGHT.toString()) {
     return Style.LIGHT;
   } else if (input === MapStyle.DARK || input === MapStyle.DARK.toString()) {
     return Style.DARK;

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -144,6 +144,9 @@ const _getMapStyle = (input: any): any => {
   if (/^mapbox:\/\/styles/.test(input)) {
     return input;
   }
+  if (/^http:\/\//.test(input) || /^https:\/\//.test(input) || /^file:\/\//.test(input)) {
+    return input;
+  }
   if (input === MapStyle.LIGHT || input === MapStyle.LIGHT.toString()) {
     return Style.LIGHT;
   } else if (input === MapStyle.DARK || input === MapStyle.DARK.toString()) {

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -141,7 +141,11 @@ export class MapboxView extends MapboxViewBase {
 const _getMapStyle = (input: any): any => {
   const Style = com.mapbox.mapboxsdk.constants.Style;
   // allow for a style URL to be passed
-  if (/^mapbox:\/\/styles/.test(input) || /^http:\/\//.test(input) || /^https:\/\//.test(input) || /^file:\/\//.test(input)) {
+  if (/^mapbox:\/\/styles/.test(input) || /^http:\/\//.test(input) || /^https:\/\//.test(input)) {
+    return input;
+  } else if (/^assets:\/\//.test(input)) {
+    let assetsPath = 'asset://app/assets/';
+    input = input.replace('assets://', assetsPath);
     return input;
   } else if (input === MapStyle.LIGHT || input === MapStyle.LIGHT.toString()) {
     return Style.LIGHT;

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -65,10 +65,7 @@ const _setMapboxMapOptions = (mapView: MGLMapView, settings) => {
 };
 
 const _getMapStyle = (input: any): NSURL => {
-  if (/^mapbox:\/\/styles/.test(input)) {
-    // allow for a style URL to be passed
-    return NSURL.URLWithString(input);
-  } else if (/^http:\/\//.test(input) || /^https:\/\//.test(input) || /^file:\/\//.test(input)) {
+  if (/^mapbox:\/\/styles/.test(input) || /^http:\/\//.test(input) || /^https:\/\//.test(input) || /^file:\/\//.test(input)) {
     return NSURL.URLWithString(input);
   } else if (input === MapStyle.LIGHT || input === MapStyle.LIGHT.toString()) {
     return MGLStyle.lightStyleURL;

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -68,6 +68,8 @@ const _getMapStyle = (input: any): NSURL => {
   if (/^mapbox:\/\/styles/.test(input)) {
     // allow for a style URL to be passed
     return NSURL.URLWithString(input);
+  } else if (/^http:\/\//.test(input) || /^https:\/\//.test(input) || /^file:\/\//.test(input)) {
+    return NSURL.URLWithString(input);
   } else if (input === MapStyle.LIGHT || input === MapStyle.LIGHT.toString()) {
     return MGLStyle.lightStyleURL;
   } else if (input === MapStyle.DARK || input === MapStyle.DARK.toString()) {

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -67,9 +67,9 @@ const _setMapboxMapOptions = (mapView: MGLMapView, settings) => {
 const _getMapStyle = (input: any): NSURL => {
   if (/^mapbox:\/\/styles/.test(input) || /^http:\/\//.test(input) || /^https:\/\//.test(input)) {
     return NSURL.URLWithString(input);
-  } else if (/^assets:\/\//.test(input)) {
-    let assetPath = 'file://' + fs.knownFolders.currentApp().path + '/assets/';
-    input = input.replace('assets://', assetPath);
+  } else if (/^~\//.test(input)) {
+    var assetPath = 'file://' + fs.knownFolders.currentApp().path + '/';
+    input = input.replace(/^~\//, assetPath);
     return NSURL.URLWithString(input);
   } else if (input === MapStyle.LIGHT || input === MapStyle.LIGHT.toString()) {
     return MGLStyle.lightStyleURL;

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -65,7 +65,11 @@ const _setMapboxMapOptions = (mapView: MGLMapView, settings) => {
 };
 
 const _getMapStyle = (input: any): NSURL => {
-  if (/^mapbox:\/\/styles/.test(input) || /^http:\/\//.test(input) || /^https:\/\//.test(input) || /^file:\/\//.test(input)) {
+  if (/^mapbox:\/\/styles/.test(input) || /^http:\/\//.test(input) || /^https:\/\//.test(input)) {
+    return NSURL.URLWithString(input);
+  } else if (/^assets:\/\//.test(input)) {
+    let assetPath = 'file://' + fs.knownFolders.currentApp().path + '/assets/';
+    input = input.replace('assets://', assetPath);
     return NSURL.URLWithString(input);
   } else if (input === MapStyle.LIGHT || input === MapStyle.LIGHT.toString()) {
     return MGLStyle.lightStyleURL;


### PR DESCRIPTION
Hi
I needed to load a different than "native mapbox style" in my map.
I added the ability to load a json map style file definition with a new special url pointing at the "assets" nativescript directory.
The Url is `assets://` and points to the `/app/assets/` directory of your project.
Usage example : 
```
onMapReady(args) {
                console.log("Switching Style");
                args.map.setMapStyle("assets://RM-raster-style.json");
}
```
Tell me what you think and if you think this is a good approach.
Cheers