### PR TITLE
configurable padding for "setViewport" method.

### DIFF
--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -820,13 +820,14 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         };
 
         let animated = options.animated === undefined || options.animated;
-
-        let padding: UIEdgeInsets = {
+        
+        // support defined padding
+        let padding: UIEdgeInsets = Mapbox.merge(options.padding === undefined ? {} : options.padding, {
           top: 25,
           left: 25,
           bottom: 25,
           right: 25
-        };
+        });
 
         theMap.setVisibleCoordinateBoundsEdgePaddingAnimated(bounds, padding, animated);
         resolve();


### PR DESCRIPTION
handy for views with overlays on top and/or bottom of MapView that require additional padding.