### PR TITLE
Issue #302 ios setMapStyle() race condition fix

### DIFF
--- a/src/mapbox.common.ts
+++ b/src/mapbox.common.ts
@@ -165,6 +165,13 @@ export interface SetViewportOptions {
    * Default true.
    */
   animated?: boolean;
+
+  /**
+  * padding
+  */
+
+  padding?: number;
+
 }
 
 export interface DeleteOfflineRegionOptions {


### PR DESCRIPTION
This merge request fixes two issues:

- this compile time error:

```
mapbox.ios.ts:851:58 - error TS2339: Property 'padding' does not exist on type 'SetViewportOptions'.
```
- the race condition in mapbox.ios.ts setMapStyle() where it returns immediately before the style has a chance to load. 

