### PR TITLE
fix padding options viewport android

### DIFF
--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -1228,9 +1228,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
             .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.south, options.bounds.west))
             .build();
 
-        const padding = 25,
-            animated = options.animated === undefined || options.animated,
-            durationMs = animated ? 1000 : 0;
+        const padding = options.padding ? options.padding : 25;
+        const animated = options.animated === undefined || options.animated;
+        const durationMs = animated ? 1000 : 0;
 
         theMap.mapboxMap.easeCamera(
             com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newLatLngBounds(bounds, padding),


### PR DESCRIPTION
Current version appears to always use `25` for padding on setViewPort method on Android.

This adds ternary to check options.padding and default to 25 if not provided.