### PR TITLE
Android Crash Fix - Activity Events

### DIFF
--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -551,7 +551,12 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   private _mapboxMapInstance: any;
   private _mapboxViewInstance: any;
+
+  // keep track of the activity the map was created in so other spawned
+  // activities don't cause unwanted side effects. See Android Activity Events below.
+
   private _activity: string;
+
   // the user location component
 
   private _locationComponent : any = false;

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2719,8 +2719,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         const styleURL = this._getMapStyle( options.style );
 
         const bounds = new com.mapbox.mapboxsdk.geometry.LatLngBounds.Builder()
-            .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.north,
-              options.bounds.east))
+            .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.north, options.bounds.east))
             .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.south, options.bounds.west))
             .build();
 

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -551,7 +551,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   private _mapboxMapInstance: any;
   private _mapboxViewInstance: any;
-
+  private _activity: string;
   // the user location component
 
   private _locationComponent : any = false;
@@ -621,6 +621,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
     this.eventCallbacks[ 'click' ] = [];
 
+    this._activity = application.android.foregroundActivity;
+
     // When we receive events from Android we need to inform the API.
     //
     // start
@@ -629,7 +631,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
       console.log( "Mapbox::constructor: activityStartedEvent Event: " + args.eventName + ", Activity: " + args.activity);
 
-      if ( this._mapboxViewInstance ) {
+      if ( this._mapboxViewInstance && this._activity === args.activity) {
 
         console.log( "Mapbox::constructor(): calling onStart()" );
 
@@ -644,7 +646,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
       console.log( "Mapbox::constructor:: activityPausedEvent Event: " + args.eventName + ", Activity: " + args.activity);
 
-      if ( this._mapboxViewInstance ) {
+      if ( this._mapboxViewInstance && this._activity === args.activity) {
 
         console.log( "Mapbox::constructor(): calling onPause()" );
 
@@ -659,7 +661,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
       console.log( "Mapbox::constructor: activityResumedEvent Event: " + args.eventName + ", Activity: " + args.activity);
 
-      if ( this._mapboxViewInstance ) {
+      if ( this._mapboxViewInstance && this._activity === args.activity) {
 
         console.log( "Mapbox::constructor(): calling onResume() - destroyed flag is:", this._mapboxViewInstance.isDestroyed() );
 
@@ -674,7 +676,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
       console.log( "Mapbox::constructor: activityStoppedEvent Event: " + args.eventName + ", Activity: " + args.activity);
 
-      if ( this._mapboxViewInstance ) {
+      if ( this._mapboxViewInstance && this._activity === args.activity) {
 
         console.log( "Mapbox::constructor(): calling onStop()" );
 
@@ -689,25 +691,26 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
       console.log( "Mapbox::constructor: activityDestroyedEvent Event: " + args.eventName + ", Activity: " + args.activity);
 
-      if ( this.lineManager ) {
-        this.lineManager.onDestroy();
+      if ( this._activity === args.activity) {
+        if ( this.lineManager ) {
+          this.lineManager.onDestroy();
+        }
+
+        if ( this.circleManager ) {
+          this.circleManager.onDestroy();
+        }
+
+        if ( this.symbolManager ) {
+          this.symbolManager.onDestroy();
+        }
+
+        if ( this._mapboxViewInstance ) {
+
+          console.log( "Mapbox::constructor(): calling onDestroy()" );
+
+          this._mapboxViewInstance.onDestroy();
+        }
       }
-
-      if ( this.circleManager ) {
-        this.circleManager.onDestroy();
-      }
-
-      if ( this.symbolManager ) {
-        this.symbolManager.onDestroy();
-      }
-
-      if ( this._mapboxViewInstance ) {
-
-        console.log( "Mapbox::constructor(): calling onDestroy()" );
-
-        this._mapboxViewInstance.onDestroy();
-      }
-
     });
 
     // savestate
@@ -716,7 +719,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
       console.log( "Mapbox::constructor: saveActivityStateEvent Event: " + args.eventName + ", Activity: " + args.activity + ", Bundle: " + args.bundle);
 
-      if ( this._mapboxViewInstance ) {
+      if ( this._mapboxViewInstance && this._activity === args.activity) {
 
         console.log( "Mapbox::constructor(): saving instance state" );
 
@@ -2716,7 +2719,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         const styleURL = this._getMapStyle( options.style );
 
         const bounds = new com.mapbox.mapboxsdk.geometry.LatLngBounds.Builder()
-            .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.north, options.bounds.east))
+            .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.north,
+              options.bounds.east)
             .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.south, options.bounds.west))
             .build();
 

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2720,9 +2720,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
         const bounds = new com.mapbox.mapboxsdk.geometry.LatLngBounds.Builder()
             .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.north,
-              options.bounds.east)
+              options.bounds.east))
             .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.south, options.bounds.west))
-            .build());
+            .build();
 
         const retinaFactor = utils.layout.getDisplayDensity();
 

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -2722,7 +2722,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
             .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.north,
               options.bounds.east)
             .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.south, options.bounds.west))
-            .build();
+            .build());
 
         const retinaFactor = utils.layout.getDisplayDensity();
 


### PR DESCRIPTION
#353 Issue explained here.

I did some investigation into why the app was crashing and noticed that the `application.android.on( application.AndroidApplication.XXXX)` events were being triggered from the Google sign-in activity as well as the activity where the map exists. So when the Google sign-in process finishes, it triggers `activityDestroyed` which this plugin is listening for which causes the map to get destroyed and ends up causing the app to crash.

My solution is to keep track of what activity the map was created in, and then whenever an `application.android.on( application.AndroidApplication.XXXX)` event is triggered we check whether the activity triggering this is the activity the map exists in.