### PR TITLE
Add support for featurecollections and expressions in geojson format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ demo/platforms
 node_modules
 demo/hooks/
 publish/package/
+publish/dist/
 ngdemo/lib
 ngdemo/platoforms
 ngdemo/node_modules

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -113,12 +113,14 @@ export function onMapReady(args) {
   ).then(() => {
     console.log("main-page Markers added");
     setTimeout(() => {
-      map.queryRenderedFeatures({
+      const result = map.queryRenderedFeatures({
         point: {
           lat: 52.3602160,
           lng: 4.8891680
         }
-      }).then(result => console.log(JSON.stringify(result)));
+      });
+
+      console.log(JSON.stringify(result));
     }, 1000);
   }).catch( ( error ) => {
     console.error( "main-page: error adding markers:", error );

--- a/src/mapbox.android.ts
+++ b/src/mapbox.android.ts
@@ -91,17 +91,17 @@ export class MapboxView extends MapboxViewBase {
 
   private settings: any = null;
 
-  private gcFixIndex : number;
+  private gcFixIndex: number;
 
   // whether or not the view has already been initialized. 
   // see initNativeView()
 
-  private initialized : boolean = false;
+  private initialized: boolean = false;
 
   constructor() {
     super();
 
-    console.log( "MapboxView::constructor(): building new MapboxView object." );
+    console.log("MapboxView::constructor(): building new MapboxView object.");
 
     this.gcFixInit();
   }
@@ -114,7 +114,7 @@ export class MapboxView extends MapboxViewBase {
   * @todo 
   */
 
-  setConfig( settings : any ) {
+  setConfig(settings: any) {
 
     // zoom level is not applied unless center is set
 
@@ -129,7 +129,7 @@ export class MapboxView extends MapboxViewBase {
 
     this.settings = settings;
   }
-  
+
   // ------------------------------------------------------
 
   /**
@@ -140,20 +140,20 @@ export class MapboxView extends MapboxViewBase {
 
   gcFixInit() {
 
-    if ( typeof global[ 'MapboxView' ] == 'undefined' ) {
+    if (typeof global['MapboxView'] == 'undefined') {
       this.gcFixIndex = 0;
-      global[ 'MapboxView' ] = [
+      global['MapboxView'] = [
         {}
       ];
 
     } else {
-      global[ 'MapboxView' ].push( {} );
-      this.gcFixIndex = global[ 'MapboxView' ].length - 1;
+      global['MapboxView'].push({});
+      this.gcFixIndex = global['MapboxView'].length - 1;
     }
 
-    console.log( "MapboxView::gcFixInit(): index is:", this.gcFixIndex );
-  }  
-  
+    console.log("MapboxView::gcFixInit(): index is:", this.gcFixIndex);
+  }
+
   // ------------------------------------------------------
 
   /**
@@ -176,9 +176,9 @@ export class MapboxView extends MapboxViewBase {
   * @param {any} ref the object reference to store.
   */
 
-  gcFix( key : string, ref : any ) {
+  gcFix(key: string, ref: any) {
 
-    global[ 'MapboxView' ][ this.gcFixIndex ][ key ] = ref;
+    global['MapboxView'][this.gcFixIndex][key] = ref;
 
   }
 
@@ -189,7 +189,7 @@ export class MapboxView extends MapboxViewBase {
   */
 
   gcClear() {
-    global[ 'MapboxView' ][ this.gcFixIndex ] = null;
+    global['MapboxView'][this.gcFixIndex] = null;
   }
 
   // ------------------------------------------------------
@@ -209,9 +209,9 @@ export class MapboxView extends MapboxViewBase {
   * @see Mapbox
   */
 
-  public getMapboxApi() : any {
+  public getMapboxApi(): any {
     return this.mapbox;
-  } 
+  }
 
   // -------------------------------------------------------
 
@@ -234,103 +234,103 @@ export class MapboxView extends MapboxViewBase {
   *
   * @todo check this.
   */
- 
+
   public createNativeView(): Object {
 
-    console.log( "MapboxView:createNativeView(): top" );
+    console.log("MapboxView:createNativeView(): top");
 
-    let nativeView = new android.widget.FrameLayout( this._context );
+    let nativeView = new android.widget.FrameLayout(this._context);
 
-    this.gcFix( 'android.widget.FrameLayout', nativeView );
+    this.gcFix('android.widget.FrameLayout', nativeView);
 
-/*
-
-    theMap.mapboxMap.setOnInfoWindowClickListener(
-      new com.mapbox.mapboxsdk.maps.MapboxMap.OnInfoWindowClickListener({
-        onInfoWindowClick: (marker) => {
-          let cachedMarker = _getClickedMarkerDetails(marker);
-          if (cachedMarker && cachedMarker.onCalloutTap) {
-            cachedMarker.onCalloutTap(cachedMarker);
-          }
-          return true;
-        }
-      })
-    );
-
-    const iconFactory = com.mapbox.mapboxsdk.annotations.IconFactory.getInstance(application.android.context);
-
-    // if any markers need to be downloaded from the web they need to be available synchronously, so fetch them first before looping
-
-    _downloadMarkerImages(markers).then( updatedMarkers => {
-      for (let m in updatedMarkers) {
-        let marker: any = updatedMarkers[m];
-        _markers.push(marker);
-        let markerOptions = new com.mapbox.mapboxsdk.annotations.MarkerOptions();
-        markerOptions.setTitle(marker.title);
-        markerOptions.setSnippet(marker.subtitle);
-        markerOptions.setPosition(new com.mapbox.mapboxsdk.geometry.LatLng(parseFloat(marker.lat), parseFloat(marker.lng)));
-
-        if (marker.icon) {
-          // for markers from url see UrlMarker in https://github.com/mapbox/mapbox-gl-native/issues/5370
-          if (marker.icon.startsWith("res://")) {
-            let resourceName = marker.icon.substring(6);
-            let res = utils.ad.getApplicationContext().getResources();
-            let identifier = res.getIdentifier(resourceName, "drawable", utils.ad.getApplication().getPackageName());
-            if (identifier === 0) {
-              console.log(`No icon found for this device density for icon ' ${marker.icon}'. Falling back to the default icon.`);
-            } else {
-              markerOptions.setIcon(iconFactory.fromResource(identifier));
-            }
-          } else if (marker.icon.startsWith("http")) {
-            if (marker.iconDownloaded !== null) {
-              markerOptions.setIcon(iconFactory.fromBitmap(marker.iconDownloaded));
-            }
-          } else {
-            console.log("Please use res://resourceName, http(s)://imageUrl or iconPath to use a local path");
-          }
-
-          marker.update = (newSettings: MapboxMarker) => {
-            for (let m in _markers) {
-              let _marker: MapboxMarker = _markers[m];
-              if (marker.id === _marker.id) {
-
-                if (newSettings.onTap !== undefined) {
-                  _marker.onTap = newSettings.onTap;
-                }
-
-                if (newSettings.onCalloutTap !== undefined) {
-                  _marker.onCalloutTap = newSettings.onCalloutTap;
-                }
-
-                if (newSettings.title !== undefined) {
-                  _marker.title = newSettings.title;
-                  _marker.android.setTitle(newSettings.title);
-                }
-
-                if (newSettings.subtitle !== undefined) {
-                  _marker.subtitle = newSettings.title;
-                  _marker.android.setSnippet(newSettings.subtitle);
-                }
-
-                if (newSettings.lat && newSettings.lng) {
-                  _marker.lat = newSettings.lat;
-                  _marker.lng = newSettings.lng;
-                  _marker.android.setPosition(new com.mapbox.mapboxsdk.geometry.LatLng(parseFloat(<any>newSettings.lat), parseFloat(<any>newSettings.lng)));
-                }
-
-                if (newSettings.selected) {
-                  theMap.mapboxMap.selectMarker(_marker.android);
-                }
+    /*
+    
+        theMap.mapboxMap.setOnInfoWindowClickListener(
+          new com.mapbox.mapboxsdk.maps.MapboxMap.OnInfoWindowClickListener({
+            onInfoWindowClick: (marker) => {
+              let cachedMarker = _getClickedMarkerDetails(marker);
+              if (cachedMarker && cachedMarker.onCalloutTap) {
+                cachedMarker.onCalloutTap(cachedMarker);
               }
+              return true;
             }
-          };
-        }
-      } // end of for loop
-    }); // end of _downloadMarkerImages()
+          })
+        );
+    
+        const iconFactory = com.mapbox.mapboxsdk.annotations.IconFactory.getInstance(application.android.context);
+    
+        // if any markers need to be downloaded from the web they need to be available synchronously, so fetch them first before looping
+    
+        _downloadMarkerImages(markers).then( updatedMarkers => {
+          for (let m in updatedMarkers) {
+            let marker: any = updatedMarkers[m];
+            _markers.push(marker);
+            let markerOptions = new com.mapbox.mapboxsdk.annotations.MarkerOptions();
+            markerOptions.setTitle(marker.title);
+            markerOptions.setSnippet(marker.subtitle);
+            markerOptions.setPosition(new com.mapbox.mapboxsdk.geometry.LatLng(parseFloat(marker.lat), parseFloat(marker.lng)));
+    
+            if (marker.icon) {
+              // for markers from url see UrlMarker in https://github.com/mapbox/mapbox-gl-native/issues/5370
+              if (marker.icon.startsWith("res://")) {
+                let resourceName = marker.icon.substring(6);
+                let res = utils.ad.getApplicationContext().getResources();
+                let identifier = res.getIdentifier(resourceName, "drawable", utils.ad.getApplication().getPackageName());
+                if (identifier === 0) {
+                  console.log(`No icon found for this device density for icon ' ${marker.icon}'. Falling back to the default icon.`);
+                } else {
+                  markerOptions.setIcon(iconFactory.fromResource(identifier));
+                }
+              } else if (marker.icon.startsWith("http")) {
+                if (marker.iconDownloaded !== null) {
+                  markerOptions.setIcon(iconFactory.fromBitmap(marker.iconDownloaded));
+                }
+              } else {
+                console.log("Please use res://resourceName, http(s)://imageUrl or iconPath to use a local path");
+              }
+    
+              marker.update = (newSettings: MapboxMarker) => {
+                for (let m in _markers) {
+                  let _marker: MapboxMarker = _markers[m];
+                  if (marker.id === _marker.id) {
+    
+                    if (newSettings.onTap !== undefined) {
+                      _marker.onTap = newSettings.onTap;
+                    }
+    
+                    if (newSettings.onCalloutTap !== undefined) {
+                      _marker.onCalloutTap = newSettings.onCalloutTap;
+                    }
+    
+                    if (newSettings.title !== undefined) {
+                      _marker.title = newSettings.title;
+                      _marker.android.setTitle(newSettings.title);
+                    }
+    
+                    if (newSettings.subtitle !== undefined) {
+                      _marker.subtitle = newSettings.title;
+                      _marker.android.setSnippet(newSettings.subtitle);
+                    }
+    
+                    if (newSettings.lat && newSettings.lng) {
+                      _marker.lat = newSettings.lat;
+                      _marker.lng = newSettings.lng;
+                      _marker.android.setPosition(new com.mapbox.mapboxsdk.geometry.LatLng(parseFloat(<any>newSettings.lat), parseFloat(<any>newSettings.lng)));
+                    }
+    
+                    if (newSettings.selected) {
+                      theMap.mapboxMap.selectMarker(_marker.android);
+                    }
+                  }
+                }
+              };
+            }
+          } // end of for loop
+        }); // end of _downloadMarkerImages()
+    
+    */
 
-*/
-
-    console.log( "MapboxView:createNativeView(): bottom" );
+    console.log("MapboxView:createNativeView(): bottom");
 
     return nativeView;
   }
@@ -360,26 +360,26 @@ export class MapboxView extends MapboxViewBase {
 
   public initNativeView(): void {
 
-    console.log( "MapboxView::initNativeView(): top" );
+    console.log("MapboxView::initNativeView(): top");
 
     (<any>this.nativeView).owner = this;
     super.initNativeView();
 
-    this.on( 'loaded', () => {
-      console.log( "MapboxView::initNativeView(): on - loaded" );
+    this.on('loaded', () => {
+      console.log("MapboxView::initNativeView(): on - loaded");
 
-      if ( ! this.initialized ) {
+      if (!this.initialized) {
         this.initMap();
         this.initialized = true;
       }
 
     });
 
-    this.on( 'unloaded', () => {
-      console.log( "MapboxView::initNativeView(): on - unloaded" );
+    this.on('unloaded', () => {
+      console.log("MapboxView::initNativeView(): on - unloaded");
     });
 
-    console.log( "MapboxView::initNativeView(): bottom" );
+    console.log("MapboxView::initNativeView(): bottom");
 
   }
 
@@ -397,19 +397,19 @@ export class MapboxView extends MapboxViewBase {
 
   async disposeNativeView(): Promise<void> {
 
-    console.log( "MapboxView::disposeNativeView(): top" );
+    console.log("MapboxView::disposeNativeView(): top");
 
     (<any>this.nativeView).owner = null;
 
     await this.mapbox.destroy();
 
-    console.log( "MapboxView::disposeNativeView(): after mapbox.destroy()" );
+    console.log("MapboxView::disposeNativeView(): after mapbox.destroy()");
 
     this.gcClear();
 
     super.disposeNativeView();
 
-    console.log( "MapboxView::disposeNativeView(): bottom" );
+    console.log("MapboxView::disposeNativeView(): bottom");
 
   }
 
@@ -430,9 +430,9 @@ export class MapboxView extends MapboxViewBase {
 
   private initMap(): void {
 
-    console.log( "MapboxView:initMap(): top - accessToken is '" + this.config.accessToken + "'", this.config );
+    console.log("MapboxView:initMap(): top - accessToken is '" + this.config.accessToken + "'", this.config);
 
-    if ( ! this.nativeMapView && ( this.config.accessToken || this.settings.accessToken )) {
+    if (!this.nativeMapView && (this.config.accessToken || this.settings.accessToken)) {
 
       this.mapbox = new Mapbox();
 
@@ -443,7 +443,7 @@ export class MapboxView extends MapboxViewBase {
       let options = {
         context: this._context,
         parentView: this.nativeView,
-        onLocationPermissionGranted: ( event ) => {
+        onLocationPermissionGranted: (event) => {
 
           this.notify({
             eventName: MapboxViewBase.locationPermissionGrantedEvent,
@@ -453,7 +453,7 @@ export class MapboxView extends MapboxViewBase {
           });
 
         },
-        onLocationPermissionDenied: ( event ) => {
+        onLocationPermissionDenied: (event) => {
 
           this.notify({
             eventName: MapboxViewBase.locationPermissionDeniedEvent,
@@ -463,14 +463,14 @@ export class MapboxView extends MapboxViewBase {
           });
 
         },
-        onMapReady: ( map ) => {
+        onMapReady: (map) => {
 
-          console.log( "MapboxView::initMap(): onMapReady event - calling notify with the MapboxViewBase.mapReadyEvent" );
+          console.log("MapboxView::initMap(): onMapReady event - calling notify with the MapboxViewBase.mapReadyEvent");
 
-          if ( this.hasListeners( MapboxViewBase.mapReadyEvent ) ) {
-            console.log( "MapboxView::initMap(): onMapReady has listeners." );
+          if (this.hasListeners(MapboxViewBase.mapReadyEvent)) {
+            console.log("MapboxView::initMap(): onMapReady has listeners.");
           } else {
-            console.log( "MapboxView::initMap(): onMapReady DOES NOT HAVE listeners." );
+            console.log("MapboxView::initMap(): onMapReady DOES NOT HAVE listeners.");
           }
 
           this.notify({
@@ -481,9 +481,9 @@ export class MapboxView extends MapboxViewBase {
           });
 
         },
-        onScrollEvent: ( event ) => {
+        onScrollEvent: (event) => {
 
-          console.log( "MapboxView::initMap(): onScrollEvent event" );
+          console.log("MapboxView::initMap(): onScrollEvent event");
 
           this.notify({
             eventName: MapboxViewBase.scrollEvent,
@@ -494,9 +494,9 @@ export class MapboxView extends MapboxViewBase {
           });
 
         },
-        onMoveBeginEvent: ( event ) => {
+        onMoveBeginEvent: (event) => {
 
-          console.log( "MapboxView::initMap(): onMoveBeginEvent event" );
+          console.log("MapboxView::initMap(): onMoveBeginEvent event");
 
           this.notify({
             eventName: MapboxViewBase.moveBeginEvent,
@@ -510,21 +510,21 @@ export class MapboxView extends MapboxViewBase {
 
       };  // end of options
 
-      console.log( "MapboxView::initMap(): this.config is:", this.config );
+      console.log("MapboxView::initMap(): this.config is:", this.config);
 
-      if ( ! this.settings ) {
-        this.settings = Mapbox.merge( this.config, Mapbox.defaults );
+      if (!this.settings) {
+        this.settings = Mapbox.merge(this.config, Mapbox.defaults);
       } else {
-        this.settings = Mapbox.merge( this.settings, Mapbox.defaults );
+        this.settings = Mapbox.merge(this.settings, Mapbox.defaults);
       }
 
-      this.settings = Mapbox.merge( this.settings, options );
+      this.settings = Mapbox.merge(this.settings, options);
 
-      console.log( "MapboxView::initMap(): before show." );
+      console.log("MapboxView::initMap(): before show.");
 
-      this.mapbox.show( this.settings );
+      this.mapbox.show(this.settings);
 
-      console.log( "MapboxView::initMap(): bottom." );
+      console.log("MapboxView::initMap(): bottom.");
 
     }
   }
@@ -559,7 +559,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   // the user location component
 
-  private _locationComponent : any = false;
+  private _locationComponent: any = false;
 
   /**
   * the permissionsManager
@@ -567,19 +567,18 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @link https://docs.mapbox.com/android/core/overview/#permissionsmanager
   */
 
-  private _permissionsManager : any = false
+  private _permissionsManager: any = false
 
   // access token
 
-  private _accessToken : string = '';
+  private _accessToken: string = '';
 
   // annotation managers.
 
-  private circleManager : any = null;
-  private lineManager : any = null;
-  private symbolManager : any = null;
+  private circleManager: any = null;
+  private symbolManager: any = null;
 
-  private _offlineManager : any;
+  private _offlineManager: any;
 
   // event listeners
 
@@ -587,32 +586,23 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   private onDidFinishLoadingMapListener;
   private onMapReadyCallback;
   private onDidFinishLoadingStyleListener;
-  private onAnnotationClickListener;
-  private onMapClickListener; 
+  private onMapClickListener;
   private onMapLongClickListener;
   private onMoveListener;
   private onScrollListener;
   private onFlingListener;
-  private onCameraMoveListener; 
+  private onCameraMoveListener;
   private onCameraMoveCancelListener;
   private onCameraIdleListener;
-  private onLocationClickListener;          
+  private onLocationClickListener;
 
   private _markers = [];
   private _polylines = [];
   private _polygons = [];
 
-  // list of circle layers
-
-  private circles: any = [];
-
-  // list of polylines
- 
-  private lines: any = [];
-
   // registered callbacks.
 
-  private eventCallbacks : any[] = [];
+  private eventCallbacks: any[] = [];
 
   _markerIconDownloadCache = [];
 
@@ -622,9 +612,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
     super();
 
-    console.log( "Mapbox::constructor(): building new Mapbox object." );
+    console.log("Mapbox::constructor(): building new Mapbox object.");
 
-    this.eventCallbacks[ 'click' ] = [];
+    this.eventCallbacks['click'] = [];
 
     this._activity = application.android.foregroundActivity;
 
@@ -632,13 +622,13 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     //
     // start
 
-    application.android.on( application.AndroidApplication.activityStartedEvent, ( args: application.AndroidActivityEventData ) => {
+    application.android.on(application.AndroidApplication.activityStartedEvent, (args: application.AndroidActivityEventData) => {
 
-      console.log( "Mapbox::constructor: activityStartedEvent Event: " + args.eventName + ", Activity: " + args.activity);
+      console.log("Mapbox::constructor: activityStartedEvent Event: " + args.eventName + ", Activity: " + args.activity);
 
-      if ( this._mapboxViewInstance && this._activity === args.activity) {
+      if (this._mapboxViewInstance && this._activity === args.activity) {
 
-        console.log( "Mapbox::constructor(): calling onStart()" );
+        console.log("Mapbox::constructor(): calling onStart()");
 
         this._mapboxViewInstance.onStart();
       }
@@ -647,13 +637,13 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
     // pause
 
-    application.android.on( application.AndroidApplication.activityPausedEvent, ( args: application.AndroidActivityEventData ) => {
+    application.android.on(application.AndroidApplication.activityPausedEvent, (args: application.AndroidActivityEventData) => {
 
-      console.log( "Mapbox::constructor:: activityPausedEvent Event: " + args.eventName + ", Activity: " + args.activity);
+      console.log("Mapbox::constructor:: activityPausedEvent Event: " + args.eventName + ", Activity: " + args.activity);
 
-      if ( this._mapboxViewInstance && this._activity === args.activity) {
+      if (this._mapboxViewInstance && this._activity === args.activity) {
 
-        console.log( "Mapbox::constructor(): calling onPause()" );
+        console.log("Mapbox::constructor(): calling onPause()");
 
         this._mapboxViewInstance.onPause();
       }
@@ -662,13 +652,13 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
     // resume
 
-    application.android.on( application.AndroidApplication.activityResumedEvent, ( args: application.AndroidActivityEventData ) => {
+    application.android.on(application.AndroidApplication.activityResumedEvent, (args: application.AndroidActivityEventData) => {
 
-      console.log( "Mapbox::constructor: activityResumedEvent Event: " + args.eventName + ", Activity: " + args.activity);
+      console.log("Mapbox::constructor: activityResumedEvent Event: " + args.eventName + ", Activity: " + args.activity);
 
-      if ( this._mapboxViewInstance && this._activity === args.activity) {
+      if (this._mapboxViewInstance && this._activity === args.activity) {
 
-        console.log( "Mapbox::constructor(): calling onResume() - destroyed flag is:", this._mapboxViewInstance.isDestroyed() );
+        console.log("Mapbox::constructor(): calling onResume() - destroyed flag is:", this._mapboxViewInstance.isDestroyed());
 
         this._mapboxViewInstance.onResume();
       }
@@ -677,13 +667,13 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
     // stop
 
-    application.android.on( application.AndroidApplication.activityStoppedEvent, ( args: application.AndroidActivityEventData ) => {
+    application.android.on(application.AndroidApplication.activityStoppedEvent, (args: application.AndroidActivityEventData) => {
 
-      console.log( "Mapbox::constructor: activityStoppedEvent Event: " + args.eventName + ", Activity: " + args.activity);
+      console.log("Mapbox::constructor: activityStoppedEvent Event: " + args.eventName + ", Activity: " + args.activity);
 
-      if ( this._mapboxViewInstance && this._activity === args.activity) {
+      if (this._mapboxViewInstance && this._activity === args.activity) {
 
-        console.log( "Mapbox::constructor(): calling onStop()" );
+        console.log("Mapbox::constructor(): calling onStop()");
 
         this._mapboxViewInstance.onStop();
       }
@@ -692,26 +682,22 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
     // destroy
 
-    application.android.on( application.AndroidApplication.activityDestroyedEvent, ( args: application.AndroidActivityEventData ) => {
+    application.android.on(application.AndroidApplication.activityDestroyedEvent, (args: application.AndroidActivityEventData) => {
 
-      console.log( "Mapbox::constructor: activityDestroyedEvent Event: " + args.eventName + ", Activity: " + args.activity);
+      console.log("Mapbox::constructor: activityDestroyedEvent Event: " + args.eventName + ", Activity: " + args.activity);
 
-      if ( this._activity === args.activity) {
-        if ( this.lineManager ) {
-          this.lineManager.onDestroy();
-        }
-
-        if ( this.circleManager ) {
+      if (this._activity === args.activity) {
+        if (this.circleManager) {
           this.circleManager.onDestroy();
         }
 
-        if ( this.symbolManager ) {
+        if (this.symbolManager) {
           this.symbolManager.onDestroy();
         }
 
-        if ( this._mapboxViewInstance ) {
+        if (this._mapboxViewInstance) {
 
-          console.log( "Mapbox::constructor(): calling onDestroy()" );
+          console.log("Mapbox::constructor(): calling onDestroy()");
 
           this._mapboxViewInstance.onDestroy();
         }
@@ -720,30 +706,30 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
     // savestate
 
-    application.android.on( application.AndroidApplication.saveActivityStateEvent, ( args: application.AndroidActivityBundleEventData ) => {
+    application.android.on(application.AndroidApplication.saveActivityStateEvent, (args: application.AndroidActivityBundleEventData) => {
 
-      console.log( "Mapbox::constructor: saveActivityStateEvent Event: " + args.eventName + ", Activity: " + args.activity + ", Bundle: " + args.bundle);
+      console.log("Mapbox::constructor: saveActivityStateEvent Event: " + args.eventName + ", Activity: " + args.activity + ", Bundle: " + args.bundle);
 
-      if ( this._mapboxViewInstance && this._activity === args.activity) {
+      if (this._mapboxViewInstance && this._activity === args.activity) {
 
-        console.log( "Mapbox::constructor(): saving instance state" );
+        console.log("Mapbox::constructor(): saving instance state");
 
-        this._mapboxViewInstance.onSaveInstanceState( args.bundle );
+        this._mapboxViewInstance.onSaveInstanceState(args.bundle);
       }
 
     });
 
-    application.android.on( application.AndroidApplication.activityResultEvent, ( args: application.AndroidActivityResultEventData ) => {
-      console.log( "Mapbox::constructor: activityResultEvent Event: " + args.eventName + ", Activity: " + args.activity +
+    application.android.on(application.AndroidApplication.activityResultEvent, (args: application.AndroidActivityResultEventData) => {
+      console.log("Mapbox::constructor: activityResultEvent Event: " + args.eventName + ", Activity: " + args.activity +
         ", requestCode: " + args.requestCode + ", resultCode: " + args.resultCode + ", Intent: " + args.intent);
     });
 
-    application.android.on( application.AndroidApplication.activityBackPressedEvent, ( args: application.AndroidActivityBackPressedEventData ) => {
-      console.log( "Mapbox::constructor: activityBackPressedEvent Event: " + args.eventName + ", Activity: " + args.activity);
+    application.android.on(application.AndroidApplication.activityBackPressedEvent, (args: application.AndroidActivityBackPressedEventData) => {
+      console.log("Mapbox::constructor: activityBackPressedEvent Event: " + args.eventName + ", Activity: " + args.activity);
       // Set args.cancel = true to cancel back navigation and do something custom.
     });
 
-    console.log( "Mapbox::constructor(): end of Mapbox constructor." );
+    console.log("Mapbox::constructor(): end of Mapbox constructor.");
 
   } // end of constructor
 
@@ -758,13 +744,13 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @see MapboxView::gcFix()
   */
 
-  gcFix( key : string, ref : any ) {
+  gcFix(key: string, ref: any) {
 
-    if ( typeof global[ 'Mapbox' ] == 'undefined' ) {
-      global[ 'Mapbox' ] = {};
+    if (typeof global['Mapbox'] == 'undefined') {
+      global['Mapbox'] = {};
     }
 
-    global[ 'Mapbox' ][ key ] = ref;
+    global['Mapbox'][key] = ref;
 
   }
 
@@ -775,7 +761,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   */
 
   gcClear() {
-    global[ 'Mapbox' ] = {};
+    global['Mapbox'] = {};
   }
 
   // ---------------------------------------------------------------------------------
@@ -784,14 +770,14 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * not used
   */
 
-  setMapboxViewInstance( mapboxViewInstance : any ) : void {
+  setMapboxViewInstance(mapboxViewInstance: any): void {
   }
 
   /**
   * not used
   */
 
-  setMapboxMapInstance( mapboxMapInstance : any ) : void {
+  setMapboxMapInstance(mapboxMapInstance: any): void {
   }
 
   // ---------------------------------------------------------------------------------
@@ -816,37 +802,37 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @todo FIXME: the timeout delay before showing the map works around some race condition. The source error needs to be figured out.
   */
 
-  show( options: ShowOptions ): Promise<any> {
+  show(options: ShowOptions): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
 
-        const settings = Mapbox.merge( options, Mapbox.defaults );
+        const settings = Mapbox.merge(options, Mapbox.defaults);
 
         const showIt = () => {
 
-          console.log( "Mapbox::show(): showit() top" );
+          console.log("Mapbox::show(): showit() top");
 
           // if no accessToken was set the app may crash.
           //
           // FIXME: Even if using a local server add some string. 
 
-          if ( settings.accessToken === undefined) {
-            reject( "Please set the 'accessToken' parameter" );
+          if (settings.accessToken === undefined) {
+            reject("Please set the 'accessToken' parameter");
             return;
           }
 
           // if already added, make sure it's removed first
 
-          if ( this._mapboxViewInstance ) {
+          if (this._mapboxViewInstance) {
 
-            console.log( "Mapbox::show(): view already created. Removing it." );
+            console.log("Mapbox::show(): view already created. Removing it.");
 
             let viewGroup = this._mapboxViewInstance.getParent();
             if (viewGroup !== null) {
 
-              console.log( "Mapbox::show(): view already created. Removing _mapboxViewInstance child of view parent." );
+              console.log("Mapbox::show(): view already created. Removing _mapboxViewInstance child of view parent.");
 
-              viewGroup.removeView( this._mapboxViewInstance );
+              viewGroup.removeView(this._mapboxViewInstance);
             }
           }
 
@@ -854,18 +840,18 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
           let context = application.android.context;
 
-          if ( settings.context ) {
+          if (settings.context) {
             context = settings.context;
           }
 
-          console.log( "Mapbox::show(): before getInstance()" );
+          console.log("Mapbox::show(): before getInstance()");
 
           // Per the Mapbox Android Native samples:
           //
           // "Mapbox access token is configured here. This needs to be called either in your application
           // object or in the same activity which contains the mapview."
 
-          com.mapbox.mapboxsdk.Mapbox.getInstance( context, this._accessToken );
+          com.mapbox.mapboxsdk.Mapbox.getInstance(context, this._accessToken);
 
           let mapboxMapOptions = this._getMapboxMapOptions(settings);
 
@@ -874,76 +860,76 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           // programmatically.
 
           this._mapboxViewInstance = new com.mapbox.mapboxsdk.maps.MapView(
-              context,
-              mapboxMapOptions
+            context,
+            mapboxMapOptions
           );
 
           // required per the Mapbox Android API.
 
-          this._mapboxViewInstance.onCreate( null );
+          this._mapboxViewInstance.onCreate(null);
 
           // define some listeners to inform in case the map does not
           // load.
 
           this.onDidFailLoadingMapListener = new com.mapbox.mapboxsdk.maps.MapView.OnDidFailLoadingMapListener({
-            onDidFailLoadingMap : error => {
-              console.error( "Mapbox::show(): failed to load map:", error );
+            onDidFailLoadingMap: error => {
+              console.error("Mapbox::show(): failed to load map:", error);
             }
           });
 
-          console.log( "Mapbox::show(): about on add onDidFailLoadingMapListener:", this.onDidFailLoadingMapListener );
-          
-          this._mapboxViewInstance.addOnDidFailLoadingMapListener( this.onDidFailLoadingMapListener );
+          console.log("Mapbox::show(): about on add onDidFailLoadingMapListener:", this.onDidFailLoadingMapListener);
 
-          this.gcFix( 'com.mapbox.mapboxsdk.maps.MapView.OnDidFailLoadingMapListener', this.onDidFailLoadingMapListener );
+          this._mapboxViewInstance.addOnDidFailLoadingMapListener(this.onDidFailLoadingMapListener);
+
+          this.gcFix('com.mapbox.mapboxsdk.maps.MapView.OnDidFailLoadingMapListener', this.onDidFailLoadingMapListener);
 
           this.onDidFinishLoadingMapListener = new com.mapbox.mapboxsdk.maps.MapView.OnDidFinishLoadingMapListener({
-            onDidFinishLoadingMap : map => {
-              console.log( "Mapbox::show(): finished loading map:" );
+            onDidFinishLoadingMap: map => {
+              console.log("Mapbox::show(): finished loading map:");
             }
           });
- 
-          this._mapboxViewInstance.addOnDidFinishLoadingMapListener( this.onDidFinishLoadingMapListener );
 
-          this.gcFix( 'com.mapbox.mapboxsdk.maps.MapView.OnDidFinishLoadingMapListener', this.onDidFinishLoadingMapListener );
- 
-          console.log( "Mapbox::show(): after adding fail listener()" );
+          this._mapboxViewInstance.addOnDidFinishLoadingMapListener(this.onDidFinishLoadingMapListener);
+
+          this.gcFix('com.mapbox.mapboxsdk.maps.MapView.OnDidFinishLoadingMapListener', this.onDidFinishLoadingMapListener);
+
+          console.log("Mapbox::show(): after adding fail listener()");
 
           this.onMapReadyCallback = new com.mapbox.mapboxsdk.maps.OnMapReadyCallback({
             onMapReady: mbMap => {
 
               this._mapboxMapInstance = mbMap;
 
-              console.log( "Mapbox::show(): onMapReady() with instance:", this._mapboxMapInstance );
+              console.log("Mapbox::show(): onMapReady() with instance:", this._mapboxMapInstance);
 
               // Android SDK 7.0.0 and on requires that the style be set separately after the map 
               // is initialized. We do not consider the map ready until the style has successfully
               // loaded.
 
-              console.log( "Mapbox::show(): attempting to set style '" + settings.style );
+              console.log("Mapbox::show(): attempting to set style '" + settings.style);
 
-              this.setMapStyle( settings.style ).then( ( style ) => {
+              this.setMapStyle(settings.style).then((style) => {
 
-                console.log( "Mapbox::show(): style loaded." );
+                console.log("Mapbox::show(): style loaded.");
 
                 // initialize the event handlers now that we have a constructed view.
 
-                this.initEventHandlerShim( settings, this._mapboxViewInstance );
+                this.initEventHandlerShim(settings, this._mapboxViewInstance);
 
-                this._addMarkers( settings.markers, this._mapboxViewInstance );
+                this._addMarkers(settings.markers, this._mapboxViewInstance);
 
                 if (settings.showUserLocation) {
-                  this.requestFineLocationPermission().then( () => {
-                    this.showUserLocationMarker( {} );
+                  this.requestFineLocationPermission().then(() => {
+                    this.showUserLocationMarker({});
 
                     // if we have a callback defined, call it.
 
-                    if ( settings.onLocationPermissionGranted ) {
-                      settings.onLocationPermissionGranted( this._mapboxMapInstance );
+                    if (settings.onLocationPermissionGranted) {
+                      settings.onLocationPermissionGranted(this._mapboxMapInstance);
                     }
-                  }).catch(err => { 
-                    if ( settings.onLocationPermissionDenied ) {
-                      settings.onLocationPermissionDenied( this._mapboxMapInstance );
+                  }).catch(err => {
+                    if (settings.onLocationPermissionDenied) {
+                      settings.onLocationPermissionDenied(this._mapboxMapInstance);
                     }
                   });
 
@@ -951,8 +937,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
                 // if we have an onMapReady callback fire it.
 
-                if ( settings.onMapReady ) {
-                  settings.onMapReady( this._mapboxMapInstance );
+                if (settings.onMapReady) {
+                  settings.onMapReady(this._mapboxMapInstance);
                 }
 
                 resolve({
@@ -964,54 +950,54 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
             }
           }); // end of onReady callback.
 
-          this._mapboxViewInstance.getMapAsync( this.onMapReadyCallback );
+          this._mapboxViewInstance.getMapAsync(this.onMapReadyCallback);
 
-          this.gcFix( 'com.mapbox.mapboxsdk.maps.OnMapReadyCallback', this.onMapReadyCallback );
+          this.gcFix('com.mapbox.mapboxsdk.maps.OnMapReadyCallback', this.onMapReadyCallback);
 
           // mapView.onResume();
 
-          console.log( "Mapbox::show(): after getMapAsync()" );
+          console.log("Mapbox::show(): after getMapAsync()");
 
           // we either have been given a view to add the map to or we
           // add it to the top making it full screen.
 
-          if ( settings.parentView ) {
+          if (settings.parentView) {
 
-            console.log( "Mapbox::show(): adding map to passed in view" );
+            console.log("Mapbox::show(): adding map to passed in view");
 
-            settings.parentView.addView( this._mapboxViewInstance );
+            settings.parentView.addView(this._mapboxViewInstance);
 
-          } else if ( settings.container ) {
+          } else if (settings.container) {
 
-            console.log( "Mapbox::show(): adding map to passed in container" );
+            console.log("Mapbox::show(): adding map to passed in container");
 
             // application.android.currentContext has been removed.
 
             context = application.android.foregroundActivity
 
-            if ( ! context ) {
+            if (!context) {
               context = application.android.startActivity;
             }
 
-            const mapViewLayout = new android.widget.FrameLayout( context );
+            const mapViewLayout = new android.widget.FrameLayout(context);
 
-            console.log( "Mapbox::show(): before adding mapboxViewInstance to FrameLayout" );
+            console.log("Mapbox::show(): before adding mapboxViewInstance to FrameLayout");
 
-            mapViewLayout.addView( this._mapboxViewInstance );
+            mapViewLayout.addView(this._mapboxViewInstance);
 
-            console.log( "Mapbox::show(): before adding FrameLayout to container" );
+            console.log("Mapbox::show(): before adding FrameLayout to container");
 
-            settings.container.addChild( mapViewLayout );
+            settings.container.addChild(mapViewLayout);
 
           }
 
-          console.log( "Mapbox::show(): showIt() bottom" );
+          console.log("Mapbox::show(): showIt() bottom");
 
         }; // end of showIt()
 
         // FIXME: There is some initialization error. A short delay works around this. 
 
-        setTimeout( showIt, settings.delay ? settings.delay : 200 );
+        setTimeout(showIt, settings.delay ? settings.delay : 200);
 
       } catch (ex) {
         console.log("Error in mapbox.show: " + ex);
@@ -1030,10 +1016,10 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   hide(): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
-        if ( this._mapboxViewInstance ) {
+        if (this._mapboxViewInstance) {
           const viewGroup = this._mapboxViewInstance.getParent();
           if (viewGroup !== null) {
-            viewGroup.setVisibility( android.view.View.INVISIBLE );
+            viewGroup.setVisibility(android.view.View.INVISIBLE);
           }
         }
         resolve();
@@ -1049,8 +1035,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   unhide(): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
-        if ( this._mapboxViewInstance ) {
-          this._mapboxViewInstance.getParent().setVisibility( android.view.View.VISIBLE );
+        if (this._mapboxViewInstance) {
+          this._mapboxViewInstance.getParent().setVisibility(android.view.View.VISIBLE);
           resolve();
         } else {
           reject("No map found");
@@ -1070,25 +1056,20 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * Destroy the map instance.
   */
 
-  destroy( nativeMap?: any ): Promise<any> {
-    return new Promise( async (resolve, reject) => {
+  destroy(nativeMap?: any): Promise<any> {
+    return new Promise(async (resolve, reject) => {
 
       this.clearEventListeners();
       this.gcClear();
 
-      console.log( "Mapbox::destroy(): destroying mapbox view." );
+      console.log("Mapbox::destroy(): destroying mapbox view.");
 
-      if ( this.lineManager ) {
-        this.lineManager.onDestroy();
-        this.lineManager = null;
-      }
-
-      if ( this.circleManager ) {
+      if (this.circleManager) {
         this.circleManager.onDestroy();
         this.circleManager = null;
       }
 
-      if ( this.symbolManager ) {
+      if (this.symbolManager) {
         this.symbolManager.onDestroy();
         this.symbolManager = null;
       }
@@ -1098,24 +1079,24 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
       // This is here to prevent a crash. The user code should disable/re-enable the
       // location marker.
 
-      if ( this._locationComponent ) {
+      if (this._locationComponent) {
 
-        console.log( "Mapbox::destroy(): Location marker not disabled before destroy() called." );
+        console.log("Mapbox::destroy(): Location marker not disabled before destroy() called.");
 
         await this.hideUserLocationMarker();
       }
 
-      if ( this._mapboxViewInstance ) {
+      if (this._mapboxViewInstance) {
 
         const viewGroup = this._mapboxViewInstance.getParent();
         if (viewGroup !== null) {
-          console.log( "Mapbox::destroy(): removing _mapboxViewInstance view." );
-          viewGroup.removeView( this._mapboxViewInstance );
+          console.log("Mapbox::destroy(): removing _mapboxViewInstance view.");
+          viewGroup.removeView(this._mapboxViewInstance);
         }
 
-	this._mapboxViewInstance.onPause();
-	this._mapboxViewInstance.onStop();
-	this._mapboxViewInstance.destroyDrawingCache();
+        this._mapboxViewInstance.onPause();
+        this._mapboxViewInstance.onStop();
+        this._mapboxViewInstance.destroyDrawingCache();
 
         // let the API know that we're programmatically destroying the map.
 
@@ -1145,60 +1126,56 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   private clearEventListeners() {
 
-    if ( this.onDidFailLoadingMapListener ) { 
-      this._mapboxViewInstance.removeOnDidFailLoadingMapListener( this.onDidFailLoadingMapListener );
+    if (this.onDidFailLoadingMapListener) {
+      this._mapboxViewInstance.removeOnDidFailLoadingMapListener(this.onDidFailLoadingMapListener);
     }
 
-    if ( this.onDidFinishLoadingMapListener ) { 
-      this._mapboxViewInstance.removeOnDidFinishLoadingMapListener( this.onDidFinishLoadingMapListener );
+    if (this.onDidFinishLoadingMapListener) {
+      this._mapboxViewInstance.removeOnDidFinishLoadingMapListener(this.onDidFinishLoadingMapListener);
     }
 
     if ( this.onDidFinishLoadingStyleListener ) { 
       this._mapboxViewInstance.removeOnDidFinishLoadingStyleListener( this.onDidFinishLoadingStyleListener );
     }
 
-    if (  this.onAnnotationClickListener ) { 
-      this.lineManager.removeClickListener( this.onAnnotationClickListener );
+    if (this.onDidFailLoadingMapListener) {
+      this._mapboxViewInstance.removeOnDidFailLoadingMapListener(this.onDidFailLoadingMapListener);
     }
 
-    if ( this.onDidFailLoadingMapListener ) { 
-      this._mapboxViewInstance.removeOnDidFailLoadingMapListener( this.onDidFailLoadingMapListener );
+    if (this.onMapClickListener) {
+      this._mapboxMapInstance.removeOnMapClickListener(this.onMapClickListener);
     }
 
-    if ( this.onMapClickListener ) {
-      this._mapboxMapInstance.removeOnMapClickListener( this.onMapClickListener );
+    if (this.onMapLongClickListener) {
+      this._mapboxMapInstance.removeOnMapLongClickListener(this.onMapLongClickListener);
     }
 
-    if ( this.onMapLongClickListener ) { 
-      this._mapboxMapInstance.removeOnMapLongClickListener( this.onMapLongClickListener );
+    if (this.onMoveListener) {
+      this._mapboxMapInstance.removeOnMoveListener(this.onMoveListener);
     }
 
-    if ( this.onMoveListener ) { 
-      this._mapboxMapInstance.removeOnMoveListener( this.onMoveListener );
+    if (this.onScrollListener) {
+      this._mapboxMapInstance.removeOnMoveListener(this.onScrollListener);
     }
 
-    if ( this.onScrollListener ) { 
-      this._mapboxMapInstance.removeOnMoveListener( this.onScrollListener );
+    if (this.onFlingListener) {
+      this._mapboxMapInstance.removeOnFlingListener(this.onFlingListener);
     }
 
-    if ( this.onFlingListener ) {     
-      this._mapboxMapInstance.removeOnFlingListener( this.onFlingListener );
+    if (this.onCameraMoveListener) {
+      this._mapboxMapInstance.removeOnCameraMoveListener(this.onCameraMoveListener);
     }
 
-    if ( this.onCameraMoveListener ) { 
-      this._mapboxMapInstance.removeOnCameraMoveListener( this.onCameraMoveListener );
+    if (this.onCameraMoveCancelListener) {
+      this._mapboxMapInstance.removeOnCameraMoveCancelListener(this.onCameraMoveCancelListener);
     }
 
-    if ( this.onCameraMoveCancelListener ) { 
-      this._mapboxMapInstance.removeOnCameraMoveCancelListener( this.onCameraMoveCancelListener );
+    if (this.onCameraIdleListener) {
+      this._mapboxMapInstance.removeOnCameraIdleListener(this.onCameraIdleListener);
     }
 
-    if (  this.onCameraIdleListener ) { 
-      this._mapboxMapInstance.removeOnCameraIdleListener( this.onCameraIdleListener );
-    }
-
-    if (  this.onLocationClickListener ) {
-      this._locationComponent.removeOnLocationClickListener( this.onLocationClickListener );
+    if (this.onLocationClickListener) {
+      this._locationComponent.removeOnLocationClickListener(this.onLocationClickListener);
     }
 
   }
@@ -1211,9 +1188,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * on Start
   */
 
-  onStart( nativeMap?: any ): Promise<any> {
+  onStart(nativeMap?: any): Promise<any> {
 
-    return new Promise( (resolve, reject) => {
+    return new Promise((resolve, reject) => {
 
       // super.onStart();
 
@@ -1230,17 +1207,17 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   /**
   * on Resume
   */
-  
-  onResume( nativeMapViewInstance?: any ): Promise<any> {
-    return new Promise( (resolve, reject) => {
 
-      console.log( "Mapbox::onResume(): calling resume" );
+  onResume(nativeMapViewInstance?: any): Promise<any> {
+    return new Promise((resolve, reject) => {
+
+      console.log("Mapbox::onResume(): calling resume");
 
       // super.onResume();
 
       this._mapboxViewInstance.onResume();
 
-      console.log( "Mapbox::onResume(): after calling resume on nativeMap:", this._mapboxViewInstance );
+      console.log("Mapbox::onResume(): after calling resume on nativeMap:", this._mapboxViewInstance);
 
       resolve();
 
@@ -1254,10 +1231,10 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * on Pause
   */
 
-  onPause( nativeMapViewInstance?: any ): Promise<any> {
-    return new Promise( (resolve, reject) => {
+  onPause(nativeMapViewInstance?: any): Promise<any> {
+    return new Promise((resolve, reject) => {
 
-      console.log( "Mapbox::onPause(): calling pause" );
+      console.log("Mapbox::onPause(): calling pause");
 
       // super.onPause();
 
@@ -1275,8 +1252,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * on Stop
   */
 
-  onStop( nativeMap?: any ): Promise<any> {
-    return new Promise( (resolve, reject) => {
+  onStop(nativeMap?: any): Promise<any> {
+    return new Promise((resolve, reject) => {
 
       // super.onStop();
 
@@ -1294,8 +1271,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * on Low Memory
   */
 
-  onLowMemory( nativeMap?: any ): Promise<any> {
-    return new Promise( (resolve, reject) => {
+  onLowMemory(nativeMap?: any): Promise<any> {
+    return new Promise((resolve, reject) => {
 
       // super.onLowMemory();
 
@@ -1313,8 +1290,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * on Destroy
   */
 
-  onDestroy( nativeMap?: any ): Promise<any> {
-    return new Promise( (resolve, reject) => {
+  onDestroy(nativeMap?: any): Promise<any> {
+    return new Promise((resolve, reject) => {
 
       // super.onStart();
 
@@ -1341,23 +1318,23 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @param { MapboxView } mapboxView
   */
 
-  initEventHandlerShim( settings, mapboxNativeViewInstance : any ) {
+  initEventHandlerShim(settings, mapboxNativeViewInstance: any) {
 
-    console.log( "Mapbox:initEventHandlerShim(): top" );
+    console.log("Mapbox:initEventHandlerShim(): top");
 
-    this.setOnMapClickListener( ( point: LatLng ) => {
-      return this.checkForCircleClickEvent( point );
-    }, mapboxNativeViewInstance );
+    this.setOnMapClickListener((point: LatLng) => {
+      return this.checkForClickEvent(point);
+    }, mapboxNativeViewInstance);
 
-    this.setOnMoveBeginListener( ( point: LatLng ) => {
+    this.setOnMoveBeginListener((point: LatLng) => {
 
-      console.log( "Mapbox:initEventHandlerShim(): moveBegin:", point );
+      console.log("Mapbox:initEventHandlerShim(): moveBegin:", point);
 
-      if ( typeof settings.onMoveBeginEvent != 'undefined' ) {
-        settings.onMoveBeginEvent( point );
+      if (typeof settings.onMoveBeginEvent != 'undefined') {
+        settings.onMoveBeginEvent(point);
       }
 
-    }, mapboxNativeViewInstance );
+    }, mapboxNativeViewInstance);
 
   }
 
@@ -1380,45 +1357,15 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @link https://github.com/mapbox/mapbox-android-demo/issues/540
   */
 
-  public onMapEvent( eventName, id, callback, nativeMapView? ) : void {
-
-    if ( typeof this.eventCallbacks[ eventName ] == 'undefined' ) {
-      this.eventCallbacks[ eventName ] = [];
+  public onMapEvent(eventName, id, callback, nativeMapView?): void {
+    if (typeof this.eventCallbacks[eventName] == 'undefined') {
+      this.eventCallbacks[eventName] = [];
     }
 
-    // is this event being added to a line? 
-
-    let lineEntry = this.lines.find( ( entry ) => { return entry.id == id; });
-
-    if ( lineEntry ) {
-
-      console.log( "Mapbox:on(): we have a line entry:", lineEntry );
-
-      // we have a line layer. As mentioned, Mapbox line layers do not support
-      // click handlers but Annotation plugin lines do (but they sadly do not
-      // support the nice styling that Layer lines do ... )
-
-      this.addClickableLineOverlay( lineEntry.id, nativeMapView )
-      .then( ( clickOverlay ) => {
-
-        lineEntry.clickOverlay = clickOverlay;
-
-        console.log( "Mapbox:on(): pushing id '" + id + "' with clickOverlay:", clickOverlay );
-
-        this.eventCallbacks[ eventName ].push({
-          id: id,
-          callback: callback
-        });
-      });
-
-    } else {
-
-      this.eventCallbacks[ eventName ].push({
-        id: id,
-        callback: callback
-      });
-    }
-
+    this.eventCallbacks[eventName].push({
+      id: id,
+      callback: callback
+    });
   }
 
   // ---------------------------------------------------------------
@@ -1430,13 +1377,13 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * the given layer id and event.
   */
 
-  public offMapEvent( eventName, id, nativeMapView? ) {
+  public offMapEvent(eventName, id, nativeMapView?) {
 
-    if ( typeof this.eventCallbacks[ eventName ] == 'undefined' ) {
+    if (typeof this.eventCallbacks[eventName] == 'undefined') {
       return;
     }
 
-    this.eventCallbacks[ eventName ] = this.eventCallbacks[ eventName ].filter( ( entry ) => {
+    this.eventCallbacks[eventName] = this.eventCallbacks[eventName].filter((entry) => {
       return entry.id != id;
     });
 
@@ -1445,199 +1392,41 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   // ------------------------------------------------------------------------
 
   /**
-  * handles a line click event
-  *
-  * Given a click on a line overlay, find the id of the underlying line layer
-  * an invoke any registered callbacks.
+  * checks for a click event on all geometry types.
   */
 
-  private handleLineClickEvent( clickOverlay ) {
+  private checkForClickEvent(point: LatLng): boolean {
+    console.log("Mapbox:checkForClickEvent(): got click event with point:", point);
+    let foundMatch = false;
 
-    let lineEntry = this.lines.find( ( entry ) => { 
+    // Note: currently queryRenderedFeatures only returns plain features and no additional layerinfo (like mapbox gl js does)
+    // see:  https://github.com/mapbox/mapbox-gl-native/issues/7162
+    // therefor each layer is queried individually
+    // as soon as there is a fix for this, this part can be optimized by only calling queryrendered features once
+    this.eventCallbacks['click'].forEach(evt => {
+      const features = this.queryRenderedFeatures({
+        point,
+        layerIds: [evt.id]
+      });
 
-      console.log( "Mapbox:handleLineClickEvent(): checking lineEntry clickOverlay id '" + entry.clickOverlay + "' against clickOverlay '" + clickOverlay + "'" );
-
-      return entry.clickOverlay == clickOverlay; 
-
+      // in most cases features will have a length of 1
+      // but when multiple features are on top of each other returning the array of features will make sure
+      // all information is returned
+      if (features && features.length > 0) {
+        evt.callback(features);
+        foundMatch = true;
+      }
     });
 
-    if ( ! lineEntry ) {
-      console.error( "Mapbox:handleLineClick(): click on overlay without an underlying line layer" );
-      return false;
-    }
-
-    for ( let x = 0; x < this.eventCallbacks[ 'click' ].length; x++ ) {
-      let entry = this.eventCallbacks[ 'click' ][ x ];
-
-      console.log( "Mapbox:handleLineClickEvent(): checking entry id '" + entry.id + "' against lineEnty id '" + lineEntry.id + "'" );
-
-      if ( entry.id == lineEntry.id ) {
-
-        console.log( "Mapbox:handleLineClickEvent(): calling callback for '" + entry.id + "'" );
-
-        return entry.callback( lineEntry );
-
-      }
-
-    } // end of for loop over events.
-
-    return false;
-
-  }
-
-  // ------------------------------------------------------------------------
-
-  /**
-  * checks for a click event on a circle.
-  *
-  * For the moment we have to handle map click events long hand ourselves for circles.
-  *
-  * When we catch an event we'll check the eventHandlers map to see if the 
-  * given layer is listed. If it is we invoke it's callback.
-  *
-  * If there are multiple overlapping circles only the first one in the list will be called.
-  *
-  * We also check the location of the click to see if it's inside any 
-  * circles and raise the event accordingly.
-  *
-  * @todo detect the top circle in the overlapping circles case.
-  */
-
-  private checkForCircleClickEvent( point : LatLng ) {
-
-    console.log( "Mapbox:checkForCircleClickEvent(): got click event with point:", point );
-
-    // is this point within a circle?
-
-    for ( let i = 0; i < this.circles.length; i++ ) {
-
-      console.log( "Mapbox:checkForCircleClickEvent(): checking circle with radius:", this.circles[i].radius );
-
-      if ( GeoUtils.isLocationInCircle( 
-        point.lng,
-        point.lat,
-        this.circles[i].center[0],
-        this.circles[i].center[1],
-        this.circles[i].radius )) {
-
-        console.log( "Mapbox:checkForCircleClickEvent() Point is in circle with id '" + this.circles[i].id + "' invoking callbacks, if any. Callback list is:", this.eventCallbacks );
-
-        for ( let x = 0; x < this.eventCallbacks[ 'click' ].length; x++ ) {
-          let entry = this.eventCallbacks[ 'click' ][ x ];
-
-          if ( entry.id == this.circles[i].id ) {
-
-            console.log( "Mapbox:checkForCircleClickEvent(): calling callback for '" + entry.id + "'" );
-
-            return entry.callback( point );
-
-          }
-
-        } // end of for loop over events.
-
-      }
-
-    } // end of loop over circles.
-
-    return false;
-
-  } // end of checkForCircleClickEvent()
-
-  // ------------------------------------------------------------------------
-
-  /**
-  * add Clickable Line Overlay
-  *
-  * As of this writing, Mapbox Layer lines do not support click handlers however
-  * they do offer a nice array of styling options.
-  *
-  * Annotation plugin lines do support click handlers but have limited styling
-  * options. 
-  *
-  * To wedge click handler support onto Mapbox layer lines we overlay the line
-  * with an invisible Annotation line and catch click events from that. 
-  *
-  * @param {string} lineId id of lineLayer we are to draw the clickable annotation over.. 
-  * @param {object} nativeMapView
-  *
-  * @return {Promise<any>} clickLine layer 
-  *
-  * @link https://stackoverflow.com/questions/54795079/how-to-get-a-geometry-from-a-mapbox-gl-native-geojsonsource
-  *
-  * @todo we assume a geojson source for lines. 
-  * @todo ideally I'd like to pull the geometry out of the line instead of keeping a separate copy of the coordinates around.
-  */
-
-  private addClickableLineOverlay( lineId, nativeMapView? ) {
-
-    return new Promise((resolve, reject) => {
-      try {
-
-        // we need to get the line layer from the lines array.
-
-        let lineEntry = this.lines.find( ( entry ) => { return entry.id == lineId; });
-
-        if ( ! lineEntry ) {
-          reject( "No such line with id '" + lineId + "'" );
-          return;
-        }
-
-        // we want to draw an invisible line of the same width.
-
-        let width = lineEntry.layer.getLineWidth().getValue();
-
-        console.log( "Mapbox:addClickableLineOverlay(): we have a source line of width '" + width + "'" );
-
-        // FIXME: for the moment we are carrying around the feature used to create the original line layer. 
-        //
-        // Line Layer features do not have any properties as the properties are separately set in the layer.
-
-        let feature = lineEntry.feature;
-
-        console.log( "Mapbox:addClickableLineOverlay(): after removing properties" );
-
-        feature.addNumberProperty( 'line-opacity', new java.lang.Float( 0 ) );
-        feature.addNumberProperty( 'line-width', width );
-
-        console.log( "Mapbox:addClickableLineOverlay(): after updating feature" );
-
-        // the create() method of the line manager requires a feature collection.
-
-        let featureCollection = new com.mapbox.geojson.FeatureCollection.fromFeature( feature );
-
-        this.gcFix( 'com.mapbox.geojson.FeatureCollection', featureCollection );
-      
-        let clickOverlay = this.lineManager.create( featureCollection ).get(0);
-
-        console.log( "Mapbox:addClickableLineOverlay(): after creating overlay:", clickOverlay );
-
-        // console.log( "Mapbox:addClickableLineOverlay(): got width '" + width + "' and sourceId '" + sourceId + "'" );
-        //
-        // let source = nativeMapView.mapboxMap.getStyle().getSource( sourceId );
-        //
-        // console.log( "Mapbox:addClickableLineOverlay(): got source:", source );
-        // 
-        // let features = source.querySourceFeatures( null );
-        //
-        // console.log( "Mapbox:addClickableLineOverlay(): features are:", features.get(0).getGeometry() );
-
-        resolve( clickOverlay );
-
-      } catch( ex ) {
-        console.log("MapboxaddClickableLineOverlay error: " + ex);
-          reject(ex);
-      }
-
-    });
-
-  } // end of addClickableLineOverylay()
+    return foundMatch;
+  } // end of checkForClickEvent()
 
   // ------------------------------------------------------------------------
 
   hasFineLocationPermission(): Promise<boolean> {
     return new Promise((resolve, reject) => {
       try {
-        resolve( this._fineLocationPermissionGranted() );
+        resolve(this._fineLocationPermissionGranted());
       } catch (ex) {
         console.log("Error in mapbox.hasFineLocationPermission: " + ex);
         reject(ex);
@@ -1657,33 +1446,33 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
     return new Promise((resolve, reject) => {
 
-      console.log( "Mapbox::requestFineLocationPermission()" );
+      console.log("Mapbox::requestFineLocationPermission()");
 
-      if ( hasLocationPermissions() ) {
+      if (hasLocationPermissions()) {
         resolve();
         return;
       }
 
-      if ( ! isLocationEnabled ) {
-        console.error( "Location Services are not turned on" );
-        reject( "Location services are not turned on." );
+      if (!isLocationEnabled) {
+        console.error("Location Services are not turned on");
+        reject("Location services are not turned on.");
         return;
       };
 
       // it seems the hasPermission return value here is always true under Android.
 
-      requestLocationPermissions( true, "We use this permission to show you your current location." ).then( ( hasPermission ) => {
+      requestLocationPermissions(true, "We use this permission to show you your current location.").then((hasPermission) => {
 
-        console.log( "Mapbox::requestFineLocationPermission(): hasPermission is:", hasPermission );
+        console.log("Mapbox::requestFineLocationPermission(): hasPermission is:", hasPermission);
 
-        if ( hasLocationPermissions() ) {
+        if (hasLocationPermissions()) {
 
-          console.log( "Mapbox::requestFineLocationPermission(): permission granted." );
-          resolve( true );
-          return; 
+          console.log("Mapbox::requestFineLocationPermission(): permission granted.");
+          resolve(true);
+          return;
         } else {
-          console.error( "Location Permission not granted.");
-          reject( "Location Permission Not granted" );
+          console.error("Location Permission not granted.");
+          reject("Location Permission Not granted");
           return;
         };
 
@@ -1694,10 +1483,10 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   // -------------------------------------------------------------------------
 
-  onRequestPermissionsResults( requestCode, permissions, grantResults ) {
-    console.log( "Mapbox::onRequestPermissionsResult()" );
+  onRequestPermissionsResults(requestCode, permissions, grantResults) {
+    console.log("Mapbox::onRequestPermissionsResult()");
 
-    this._permissionsManager.onRequestPermissionsResult( requestCode, permissions, grantResults );
+    this._permissionsManager.onRequestPermissionsResult(requestCode, permissions, grantResults);
 
   }
 
@@ -1720,7 +1509,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @link https://docs.mapbox.com/android/api/map-sdk/7.1.2/com/mapbox/mapboxsdk/maps/MapboxMap.html#setStyle-java.lang.String-com.mapbox.mapboxsdk.maps.Style.OnStyleLoaded-
   */
 
-  setMapStyle( style: string | MapStyle, nativeMapViewInstance?: any): Promise<any> {
+  setMapStyle(style: string | MapStyle, nativeMapViewInstance?: any): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
 
@@ -1732,32 +1521,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
         this.onDidFinishLoadingStyleListener = new com.mapbox.mapboxsdk.maps.MapView.OnDidFinishLoadingStyleListener({
           onDidFinishLoadingStyle : style => {
-
             console.log( "Mapbox:setMapStyle(): style loaded" );
-
-            // FIXME: now that the map is initialized and the style is loaded we can
-            // create the annotation managers that allow us to (hopefully) reliably
-            // receive events on lines 
-
-            this.lineManager = new com.mapbox.mapboxsdk.plugins.annotation.LineManager( this._mapboxViewInstance, this._mapboxMapInstance, this._mapboxMapInstance.getStyle() );
-
-            // FIXME: probably not necessary.
-
-            this.gcFix( 'lineManager', this.lineManager );
-
-            this.onAnnotationClickListener = new com.mapbox.mapboxsdk.plugins.annotation.OnAnnotationClickListener({
-              onAnnotationClick: line => {
-                console.log( "Mapbox:setMapStyle(): click on line:", line );
-
-                this.handleLineClickEvent( line );
-
-                return true;
-              }
-            });
-
-            this.lineManager.addClickListener( this.onAnnotationClickListener );
-
-            this.gcFix( 'com.mapbox.mapboxsdk.plugins.annotation.OnAnnotationClickListener', this.onAnnotationClickListener );
 
             resolve( style );
 
@@ -1783,15 +1547,18 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
         this.gcFix( 'com.mapbox.mapboxsdk.maps.MapView.OnDidFailLoadingMapListener', this.onDidFailLoadingMapListener );
 
+
+        console.log("Mapbox::setMapStyle(): with style:", style);
+
         let builder = new com.mapbox.mapboxsdk.maps.Style.Builder();
 
-        this._mapboxMapInstance.setStyle( 
-          builder.fromUrl( mapStyle )
+        this._mapboxMapInstance.setStyle(
+          builder.fromUrl(mapStyle)
         );
 
         // FIXME: probably not necessary.
 
-        this.gcFix( 'com.mapbox.mapboxsdk.maps.Style.Builder', builder );
+        this.gcFix('com.mapbox.mapboxsdk.maps.Style.Builder', builder);
 
       } catch (ex) {
         console.log("Error in mapbox.setMapStyle: " + ex);
@@ -1805,7 +1572,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   addMarkers(markers: MapboxMarker[], nativeMap?: any): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
-        this._addMarkers( markers, this._mapboxViewInstance );
+        this._addMarkers(markers, this._mapboxViewInstance);
         resolve();
       } catch (ex) {
         console.log("Error in mapbox.addMarkers: " + ex);
@@ -1819,7 +1586,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   removeMarkers(ids?: any, nativeMap?: any): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
-        this._removeMarkers( ids, this._mapboxViewInstance );
+        this._removeMarkers(ids, this._mapboxViewInstance);
         resolve();
       } catch (ex) {
         console.log("Error in mapbox.removeMarkers: " + ex);
@@ -1848,14 +1615,14 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
       return;
     }
 
-    if ( !this._mapboxMapInstance ) {
+    if (!this._mapboxMapInstance) {
       return;
     }
 
     this._mapboxMapInstance.setOnMarkerClickListener(
       new com.mapbox.mapboxsdk.maps.MapboxMap.OnMarkerClickListener({
         onMarkerClick: (marker) => {
-          let cachedMarker = this._getClickedMarkerDetails( marker );
+          let cachedMarker = this._getClickedMarkerDetails(marker);
           if (cachedMarker && cachedMarker.onTap) {
             cachedMarker.onTap(cachedMarker);
           }
@@ -1867,7 +1634,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     this._mapboxMapInstance.setOnInfoWindowClickListener(
       new com.mapbox.mapboxsdk.maps.MapboxMap.OnInfoWindowClickListener({
         onInfoWindowClick: (marker) => {
-          let cachedMarker = this._getClickedMarkerDetails( marker );
+          let cachedMarker = this._getClickedMarkerDetails(marker);
           if (cachedMarker && cachedMarker.onCalloutTap) {
             cachedMarker.onCalloutTap(cachedMarker);
           }
@@ -1921,7 +1688,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         marker.android = this._mapboxMapInstance.addMarker(markerOptions);
 
         if (marker.selected) {
-          this._mapboxMapInstance.selectMarker( marker.android );
+          this._mapboxMapInstance.selectMarker(marker.android);
         }
 
         marker.update = (newSettings: MapboxMarker) => {
@@ -1948,7 +1715,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
                 _marker.android.setPosition(new com.mapbox.mapboxsdk.geometry.LatLng(parseFloat(<any>newSettings.lat), parseFloat(<any>newSettings.lng)));
               }
               if (newSettings.selected) {
-                this._mapboxMapInstance.selectMarker( _marker.android );
+                this._mapboxMapInstance.selectMarker(_marker.android);
               }
             }
           }
@@ -1965,9 +1732,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @deprecated
   */
 
-  _removeMarkers(ids?, nativeMap?)  {
+  _removeMarkers(ids?, nativeMap?) {
 
-    if ( ! this._mapboxMapInstance ) {
+    if (!this._mapboxMapInstance) {
       return;
     }
 
@@ -1994,16 +1761,16 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
       try {
 
         const cameraPosition = new com.mapbox.mapboxsdk.camera.CameraPosition.Builder()
-            .target(new com.mapbox.mapboxsdk.geometry.LatLng(options.lat, options.lng))
-            .build();
+          .target(new com.mapbox.mapboxsdk.geometry.LatLng(options.lat, options.lng))
+          .build();
 
         // FIXME: Probably not necessary.
 
-        this.gcFix( 'com.mapbox.mapboxsdk.camera.CameraPosition.Builder', cameraPosition );
+        this.gcFix('com.mapbox.mapboxsdk.camera.CameraPosition.Builder', cameraPosition);
 
         if (options.animated === true) {
 
-          let newCameraPosition = com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newCameraPosition( cameraPosition );
+          let newCameraPosition = com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newCameraPosition(cameraPosition);
 
           this._mapboxMapInstance.animateCamera(
             newCameraPosition,
@@ -2011,8 +1778,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
             null
           );
 
-          this.gcFix( 'com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newCameraPosition', newCameraPosition );
-              
+          this.gcFix('com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newCameraPosition', newCameraPosition);
+
         } else {
           this._mapboxMapInstance.setCameraPosition(cameraPosition);
         }
@@ -2058,12 +1825,12 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
           // FIXME: probably not necessary
 
-          this.gcFix( 'com.mapbox.mapboxsdk.camera.CameraUpdateFactory.zoomTo', cameraUpdate );
+          this.gcFix('com.mapbox.mapboxsdk.camera.CameraUpdateFactory.zoomTo', cameraUpdate);
 
           if (animated) {
-            this._mapboxMapInstance.easeCamera( cameraUpdate );
+            this._mapboxMapInstance.easeCamera(cameraUpdate);
           } else {
-            this._mapboxMapInstance.moveCamera( cameraUpdate );
+            this._mapboxMapInstance.moveCamera(cameraUpdate);
           }
           resolve();
         } else {
@@ -2098,17 +1865,17 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         const tilt = options.tilt ? options.tilt : 30;
 
         const cameraPositionBuilder = new com.mapbox.mapboxsdk.camera.CameraPosition.Builder()
-            .tilt(tilt);
+          .tilt(tilt);
 
         // FIXME: probably not necessary
 
-        this.gcFix( 'com.mapbox.mapboxsdk.camera.CameraPosition.Builder', cameraPositionBuilder );
+        this.gcFix('com.mapbox.mapboxsdk.camera.CameraPosition.Builder', cameraPositionBuilder);
 
         const cameraUpdate = com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newCameraPosition(cameraPositionBuilder.build());
 
         // FIXME: probably not necessary
 
-        this.gcFix( 'com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newCameraPosition', cameraUpdate );
+        this.gcFix('com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newCameraPosition', cameraUpdate);
 
         const durationMs = options.duration ? options.duration : 5000;
 
@@ -2177,40 +1944,37 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   *
   * @link https://www.mapbox.com/android-docs/api/mapbox-java/libjava-geojson/3.4.1/com/mapbox/geojson/Feature.html
   */
- 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions, nativeMap?): Promise<Array<Feature>> {
-    return new Promise((resolve, reject) => {
-      try {
 
-        const point = options.point;
-        if (point === undefined) {
-          reject("Please set the 'point' parameter");
-          return;
-        }
+  /**
+   * Note: I had to convert this to a non-async function since the mapclick event requires a boolean to be returned and this
+   * is used for that. mapclick doesn't accept a promise as a return value
+   */
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions, nativeMap?): Array<Feature> {
+    try {
 
-        const mapboxPoint = new com.mapbox.mapboxsdk.geometry.LatLng(options.point.lat, options.point.lng);
-        const screenLocation = this._mapboxMapInstance.getProjection().toScreenLocation(mapboxPoint);
-
-        if ( this._mapboxMapInstance.queryRenderedFeatures ) {
-          const features /* List<Feature> */ = this._mapboxMapInstance.queryRenderedFeatures( screenLocation, null, options.layerIds );
-          const result:Array<Feature> = [];
-          for (let i = 0; i < features.size(); i++) {
-            const feature = features.get(i);
-            result.push({
-              id: feature.id(),
-              type: feature.type(),
-              properties: JSON.parse(feature.properties().toString())
-            });
-          }
-          resolve(result);
-        } else {
-          reject("Feature not supported by this Mapbox version");
-        }
-      } catch (ex) {
-        console.log("Error in mapbox.queryRenderedFeatures: " + ex);
-        reject(ex);
+      const point = options.point;
+      if (point === undefined) {
+        throw new Error("Please set the 'point' parameter");
       }
-    });
+
+      const mapboxPoint = new com.mapbox.mapboxsdk.geometry.LatLng(options.point.lat, options.point.lng);
+      const screenLocation = this._mapboxMapInstance.getProjection().toScreenLocation(mapboxPoint);
+
+      if (this._mapboxMapInstance.queryRenderedFeatures) {
+        const features /* List<Feature> */ = this._mapboxMapInstance.queryRenderedFeatures(screenLocation, null, options.layerIds);
+        const result: Array<Feature> = [];
+        for (let i = 0; i < features.size(); i++) {
+          const feature = features.get(i);
+          result.push(JSON.parse(feature.toJson()));
+        }
+        return result;
+      } else {
+        throw new Error("Feature not supported by this Mapbox version");
+      }
+    } catch (ex) {
+      console.log("Error in mapbox.queryRenderedFeatures: " + ex);
+      return undefined;
+    }
   }
 
   // ----------------------------------------------------------------------------------
@@ -2282,7 +2046,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         }
         this._polylines.push({
           id: options.id || new Date().getTime(),
-          android: this._mapboxMapInstance.addPolyline( polylineOptions )
+          android: this._mapboxMapInstance.addPolyline(polylineOptions)
         });
         resolve();
       } catch (ex) {
@@ -2344,8 +2108,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           return;
         }
 
-        const cameraPositionBuilder = new com.mapbox.mapboxsdk.camera.CameraPosition.Builder( this._mapboxMapInstance.getCameraPosition())
-            .target(new com.mapbox.mapboxsdk.geometry.LatLng(target.lat, target.lng));
+        const cameraPositionBuilder = new com.mapbox.mapboxsdk.camera.CameraPosition.Builder(this._mapboxMapInstance.getCameraPosition())
+          .target(new com.mapbox.mapboxsdk.geometry.LatLng(target.lat, target.lng));
 
         if (options.bearing) {
           cameraPositionBuilder.bearing(options.bearing);
@@ -2362,9 +2126,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         const durationMs = options.duration ? options.duration : 10000;
 
         this._mapboxMapInstance.animateCamera(
-            com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newCameraPosition(cameraPositionBuilder.build()),
-            durationMs,
-            null);
+          com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newCameraPosition(cameraPositionBuilder.build()),
+          durationMs,
+          null);
 
         setTimeout(() => {
           resolve();
@@ -2387,19 +2151,19 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * Not returning a boolean from the listener function will cause a crash.
   */
 
-  setOnMapClickListener( listener: (data: LatLng) => void, nativeMap? : MapboxView ): Promise<any> {
+  setOnMapClickListener(listener: (data: LatLng) => boolean, nativeMap?: MapboxView): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
 
-        if (! this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
 
         this.onMapClickListener = new com.mapbox.mapboxsdk.maps.MapboxMap.OnMapClickListener({
-          onMapClick: point => {
+          onMapClick: (point: any): boolean => {
 
-            console.log( "Mapbox:setOnMapClickListener(): click event at point:", point );
+            console.log("Mapbox:setOnMapClickListener(): click event at point:", point);
 
             return listener({
               lat: point.getLatitude(),
@@ -2409,9 +2173,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           }
         });
 
-        this._mapboxMapInstance.addOnMapClickListener( this.onMapClickListener );
+        this._mapboxMapInstance.addOnMapClickListener(this.onMapClickListener);
 
-        this.gcFix( 'com.mapbox.mapboxsdk.maps.MapboxMap.OnMapClickListener', this.onMapClickListener );
+        this.gcFix('com.mapbox.mapboxsdk.maps.MapboxMap.OnMapClickListener', this.onMapClickListener);
 
         resolve();
       } catch (ex) {
@@ -2427,7 +2191,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     return new Promise((resolve, reject) => {
       try {
 
-        if ( !this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
@@ -2441,9 +2205,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           }
         });
 
-        this._mapboxMapInstance.addOnMapLongClickListener( this.onMapLongClickListener );
+        this._mapboxMapInstance.addOnMapLongClickListener(this.onMapLongClickListener);
 
-        this.gcFix( 'com.mapbox.mapboxsdk.maps.MapboxMap.OnMapLongClickListener', this.onMapLongClickListener );
+        this.gcFix('com.mapbox.mapboxsdk.maps.MapboxMap.OnMapLongClickListener', this.onMapLongClickListener);
 
         resolve();
       } catch (ex) {
@@ -2459,12 +2223,12 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     return new Promise((resolve, reject) => {
       try {
 
-        if (! this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
 
-        console.log( "Mapbox::setOnMoveBeginListener():" );
+        console.log("Mapbox::setOnMoveBeginListener():");
 
         this.onMoveListener = new com.mapbox.mapboxsdk.maps.MapboxMap.OnMoveListener({
           onMoveBegin: (detector: any /* MoveGestureDetector */) => {
@@ -2480,9 +2244,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           }
         });
 
-        this._mapboxMapInstance.addOnMoveListener( this.onMoveListener );
+        this._mapboxMapInstance.addOnMoveListener(this.onMoveListener);
 
-        this.gcFix( 'com.mapbox.mapboxsdk.maps.MapboxMap.OnMoveListener', this.onMoveListener );
+        this.gcFix('com.mapbox.mapboxsdk.maps.MapboxMap.OnMoveListener', this.onMoveListener);
 
         resolve();
       } catch (ex) {
@@ -2498,12 +2262,12 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     return new Promise((resolve, reject) => {
       try {
 
-        if (! this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
 
-        console.log( "Mapbox::setOnScrollListener():" );
+        console.log("Mapbox::setOnScrollListener():");
 
         // the 'onMove' event seems like the one closest to the iOS implementation
 
@@ -2521,9 +2285,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           }
         });
 
-        this._mapboxMapInstance.addOnMoveListener( this.onScrollListener );
+        this._mapboxMapInstance.addOnMoveListener(this.onScrollListener);
 
-        this.gcFix( 'com.mapbox.mapboxsdk.maps.MapboxMap.OnScrollListener', this.onScrollListener );
+        this.gcFix('com.mapbox.mapboxsdk.maps.MapboxMap.OnScrollListener', this.onScrollListener);
 
         resolve();
       } catch (ex) {
@@ -2539,7 +2303,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     return new Promise((resolve, reject) => {
       try {
 
-        if (! this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
@@ -2550,9 +2314,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           }
         });
 
-        this._mapboxMapInstance.addOnFlingListener( this.onFlingListener );
+        this._mapboxMapInstance.addOnFlingListener(this.onFlingListener);
 
-        this.gcFix( 'com.mapbox.mapboxsdk.maps.MapboxMap.OnFlingListener', this.onFlingListener );
+        this.gcFix('com.mapbox.mapboxsdk.maps.MapboxMap.OnFlingListener', this.onFlingListener);
 
         resolve();
       } catch (ex) {
@@ -2568,20 +2332,20 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     return new Promise((resolve, reject) => {
       try {
 
-        if ( !this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
- 
+
         this.onCameraMoveListener = new com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveListener({
           onCameraMove: () => {
             return listener();
           }
         });
 
-        this._mapboxMapInstance.addOnCameraMoveListener( this.onCameraMoveListener );
+        this._mapboxMapInstance.addOnCameraMoveListener(this.onCameraMoveListener);
 
-        this.gcFix( 'com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveListener', this.onCameraMoveListener );
+        this.gcFix('com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveListener', this.onCameraMoveListener);
 
         resolve();
       } catch (ex) {
@@ -2597,7 +2361,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     return new Promise((resolve, reject) => {
       try {
 
-        if (!this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
@@ -2608,9 +2372,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           }
         });
 
-        this._mapboxMapInstance.addOnCameraMoveCancelListener( this.onCameraMoveCancelListener );
+        this._mapboxMapInstance.addOnCameraMoveCancelListener(this.onCameraMoveCancelListener);
 
-        this.gcFix( 'com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveCanceledListener', this.onCameraMoveCancelListener );
+        this.gcFix('com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraMoveCanceledListener', this.onCameraMoveCancelListener);
 
         resolve();
       } catch (ex) {
@@ -2626,7 +2390,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     return new Promise((resolve, reject) => {
       try {
 
-        if (! this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
@@ -2637,9 +2401,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           }
         });
 
-        this._mapboxMapInstance.addOnCameraIdleListener( this.onCameraIdleListener );
+        this._mapboxMapInstance.addOnCameraIdleListener(this.onCameraIdleListener);
 
-        this.gcFix( 'com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraIdleListener', this.onCameraIdleListener );
+        this.gcFix('com.mapbox.mapboxsdk.maps.MapboxMap.OnCameraIdleListener', this.onCameraIdleListener);
 
         resolve();
       } catch (ex) {
@@ -2655,7 +2419,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     return new Promise((resolve, reject) => {
       try {
 
-        if (! this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
@@ -2684,24 +2448,24 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     return new Promise((resolve, reject) => {
       try {
 
-        if ( !this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
 
         const bounds = new com.mapbox.mapboxsdk.geometry.LatLngBounds.Builder()
-            .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.north, options.bounds.east))
-            .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.south, options.bounds.west))
-            .build();
+          .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.north, options.bounds.east))
+          .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.south, options.bounds.west))
+          .build();
 
         const padding = 25,
-            animated = options.animated === undefined || options.animated,
-            durationMs = animated ? 1000 : 0;
+          animated = options.animated === undefined || options.animated,
+          durationMs = animated ? 1000 : 0;
 
-        if ( animated ) {
+        if (animated) {
           this._mapboxMapInstance.easeCamera(
-              com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newLatLngBounds(bounds, padding),
-              durationMs);
+            com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newLatLngBounds(bounds, padding),
+            durationMs);
         } else {
           this._mapboxMapInstance.moveCamera(com.mapbox.mapboxsdk.camera.CameraUpdateFactory.newLatLngBounds(bounds, padding));
         }
@@ -2721,21 +2485,21 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   downloadOfflineRegion(options: DownloadOfflineRegionOptions): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
-        const styleURL = this._getMapStyle( options.style );
+        const styleURL = this._getMapStyle(options.style);
 
         const bounds = new com.mapbox.mapboxsdk.geometry.LatLngBounds.Builder()
-            .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.north, options.bounds.east))
-            .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.south, options.bounds.west))
-            .build();
+          .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.north, options.bounds.east))
+          .include(new com.mapbox.mapboxsdk.geometry.LatLng(options.bounds.south, options.bounds.west))
+          .build();
 
         const retinaFactor = utils.layout.getDisplayDensity();
 
         const offlineRegionDefinition = new com.mapbox.mapboxsdk.offline.OfflineTilePyramidRegionDefinition(
-            styleURL,
-            bounds,
-            options.minZoom,
-            options.maxZoom,
-            retinaFactor);
+          styleURL,
+          bounds,
+          options.minZoom,
+          options.maxZoom,
+          retinaFactor);
 
         const info = '{name:"' + options.name + '"}';
         const infoStr = new java.lang.String(info);
@@ -2747,7 +2511,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         }
         if (!this._accessToken) {
           this._accessToken = options.accessToken;
-          com.mapbox.mapboxsdk.Mapbox.getInstance( application.android.context, this._accessToken );
+          com.mapbox.mapboxsdk.Mapbox.getInstance(application.android.context, this._accessToken);
         }
 
         this._getOfflineManager().createOfflineRegion(offlineRegionDefinition, encodedMetadata, new com.mapbox.mapboxsdk.offline.OfflineManager.CreateOfflineRegionCallback({
@@ -2767,8 +2531,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
               onStatusChanged: (status) => {
                 // Calculate the download percentage and update the progress bar
                 let percentage = status.getRequiredResourceCount() >= 0 ?
-                    (100.0 * status.getCompletedResourceCount() / status.getRequiredResourceCount()) :
-                    0.0;
+                  (100.0 * status.getCompletedResourceCount() / status.getRequiredResourceCount()) :
+                  0.0;
 
                 if (options.onProgress) {
                   options.onProgress({
@@ -2910,8 +2674,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   _getOfflineManager() {
 
-    if ( ! this._offlineManager ) {
-      this._offlineManager = com.mapbox.mapboxsdk.offline.OfflineManager.getInstance( application.android.context );
+    if (!this._offlineManager) {
+      this._offlineManager = com.mapbox.mapboxsdk.offline.OfflineManager.getInstance(application.android.context);
     }
 
     return this._offlineManager;
@@ -2931,10 +2695,10 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
         // Set data-driven styling properties
         fillExtrusionLayer.setProperties(
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionColor(android.graphics.Color.LTGRAY),
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionHeight(com.mapbox.mapboxsdk.style.functions.Function.property("height", new com.mapbox.mapboxsdk.style.functions.stops.IdentityStops())),
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionBase(com.mapbox.mapboxsdk.style.functions.Function.property("min_height", new com.mapbox.mapboxsdk.style.functions.stops.IdentityStops())),
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpacity(new java.lang.Float(0.6))
+          com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionColor(android.graphics.Color.LTGRAY),
+          com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionHeight(com.mapbox.mapboxsdk.style.functions.Function.property("height", new com.mapbox.mapboxsdk.style.functions.stops.IdentityStops())),
+          com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionBase(com.mapbox.mapboxsdk.style.functions.Function.property("min_height", new com.mapbox.mapboxsdk.style.functions.stops.IdentityStops())),
+          com.mapbox.mapboxsdk.style.layers.PropertyFactory.fillExtrusionOpacity(new java.lang.Float(0.6))
         );
 
         this._mapboxMapInstance.addLayer(fillExtrusionLayer);
@@ -2955,19 +2719,25 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @link https://docs.mapbox.com/mapbox-gl-js/api/#map#addsource
   */
 
-  addSource( id : string, options: AddSourceOptions, nativeMap?): Promise<any> {
+  addSource(id: string, options: AddSourceOptions, nativeMap?): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
         const { url, type } = options;
-        const theMap = nativeMap;
+        let theMap = nativeMap;
         let source;
 
         if (!theMap) {
-          reject("No map has been loaded");
-          return;
+
+          if (!this._mapboxMapInstance) {
+            reject("No map has been loaded");
+            return;
+          }
+
+          theMap = this._mapboxMapInstance;
+
         }
 
-        if ( theMap.mapboxMap.getSource(id) ) {
+        if (theMap.getStyle().getSource(id)) {
           reject("Source exists: " + id);
           return;
         }
@@ -2976,57 +2746,34 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
           case "vector":
             source = new com.mapbox.mapboxsdk.style.sources.VectorSource(id, url);
-          break;
+            break;
 
           case 'geojson':
 
-            console.log( "Mapbox:addSource(): before addSource with geojson" );
+            console.log("Mapbox:addSource(): before addSource with geojson");
 
-            let geojsonString = JSON.stringify( options.data );
+            let geojsonString = JSON.stringify(options.data);
 
-            let feature : Feature = com.mapbox.geojson.Feature.fromJson( geojsonString );
+            let geojsonData;
 
-            console.log( "Mapbox:addSource(): adding feature" );
-
-            // com.mapbox.mapboxsdk.maps.Style
-
-            let geoJsonSource = new com.mapbox.mapboxsdk.style.sources.GeoJsonSource(
-              id,
-              feature
-            );
-
-            this._mapboxMapInstance.getStyle().addSource( geoJsonSource );
-
-            this.gcFix( 'com.mapbox.mapboxsdk.style.sources.GeoJsonSource', geoJsonSource );
-
-            // To support handling click events on lines and circles, we keep the underlying 
-            // feature.
-            //
-            // FIXME: There should be a way to get the original feature back out from the source
-            // but I have not yet figured out how.
-
-            if ( options.data.geometry.type == 'LineString' ) {
-
-              this.lines.push({
-                type: 'line',
-                id: id,
-                feature: feature
-              });
-
-            } else if ( options.data.geometry.type == 'Point' ) {
-
-              // probably a circle
-
-              this.circles.push({
-                type: 'line',
-                id: id,
-                center: options.data.geometry.coordinates
-              });
-
+            switch (options.data.type) {
+              case 'Feature':
+                geojsonData = com.mapbox.geojson.Feature.fromJson(geojsonString);
+                console.log("Mapbox:addSource(): adding feature");
+                break;
+              case 'FeatureCollection':
+                geojsonData = com.mapbox.geojson.FeatureCollection.fromJson(geojsonString);
+                console.log("Mapbox:addSource(): adding featureCollection");
+                break;
             }
 
-          break;
+            source = new com.mapbox.mapboxsdk.style.sources.GeoJsonSource(
+              id,
+              geojsonData
+            );
 
+            this.gcFix('com.mapbox.mapboxsdk.style.sources.GeoJsonSource', source);
+            break;
           default:
             reject("Invalid source type: " + type);
             return;
@@ -3039,7 +2786,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           return;
         }
 
-        theMap.mapboxMap.addSource(source);
+        theMap.getStyle().addSource(source);
         resolve();
       } catch (ex) {
         console.log("Error in mapbox.addSource: " + ex);
@@ -3054,33 +2801,23 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * remove source by id
   */
 
-  removeSource( id: string, nativeMap? ): Promise<any> {
+  removeSource(id: string, nativeMap?): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
-        const theMap = nativeMap;
+        let theMap = nativeMap;
 
         if (!theMap) {
-          reject("No map has been loaded");
-          return;
+
+          if (!this._mapboxMapInstance) {
+            reject("No map has been loaded");
+            return;
+          }
+
+          theMap = this._mapboxMapInstance;
+
         }
 
-        theMap.mapboxMap.removeSource(id);
-
-        // if we've cached the underlying feature, remove it.
-        //
-        // since we don't know if it's a line or a circle we have to check both lists.
-
-        let offset = this.lines.findIndex( ( entry ) => { return entry.id == id; });
-
-        if ( offset != -1 ) {
-          this.lines.splice( offset, 1 );
-        }
-
-        offset = this.circles.findIndex( ( entry ) => { return entry.id == id; });
-
-        if ( offset != -1 ) {
-          this.circles.splice( offset, 1 );
-        }
+        theMap.getStyle().removeSource(id);
 
         resolve();
       } catch (ex) {
@@ -3111,30 +2848,29 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @link https://docs.mapbox.com/mapbox-gl-js/style-spec/#layers
   */
 
-  public addLayer( style, nativeMapView? ) : Promise<any> {
+  public addLayer(style, nativeMapView?): Promise<any> {
 
     let retval;
 
-    switch( style.type ) {
+    switch (style.type) {
 
       case 'line':
-        retval = this.addLineLayer( style, nativeMapView );
-      break;
+        retval = this.addLineLayer(style, nativeMapView);
+        break;
 
       case 'circle':
-        retval = this.addCircleLayer( style, nativeMapView );
-      break;
+        retval = this.addCircleLayer(style, nativeMapView);
+        break;
 
       default:
 
-        retval = Promise.reject( "Mapbox:addLayer() Unsupported geometry type '" + style.type + "'" );
+        retval = Promise.reject("Mapbox:addLayer() Unsupported geometry type '" + style.type + "'");
 
-      break;
+        break;
 
     }
 
     return retval;
-
   }
 
   // -----------------------------------------------------------------------
@@ -3147,19 +2883,19 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @param {string} id
   */
 
-  public removeLayer( id : string, nativeMapViewInstance ) {
+  public removeLayer(id: string, nativeMapViewInstance) {
 
     return new Promise((resolve, reject) => {
       try {
 
-        this._mapboxMapInstance.getStyle().removeLayer( id ) ;
+        this._mapboxMapInstance.getStyle().removeLayer(id);
 
-        console.log( "Mapbox:removeLayer(): after removing layer" );
+        console.log("Mapbox:removeLayer(): after removing layer");
 
         resolve();
 
       } catch (ex) {
-        console.log( "Mapbox:removeLayer() Error : " + ex );
+        console.log("Mapbox:removeLayer() Error : " + ex);
         reject(ex);
       }
 
@@ -3242,24 +2978,24 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @link https://docs.nativescript.org/core-concepts/android-runtime/marshalling/java-to-js#array-of-primitive-types
   */
 
-  private addLineLayer( style, nativeMapViewInstance? ) : Promise<any> {
+  private addLineLayer(style, nativeMapViewInstance?): Promise<any> {
 
     return new Promise((resolve, reject) => {
       try {
 
-        if ( style.type != 'line' ) {
-          reject( "Non line style passed to addLineLayer()" );
+        if (style.type != 'line') {
+          reject("Non line style passed to addLineLayer()");
         }
 
         // the source may be of type geojson, vector,  or it may be the id of a source added by addSource().
 
         let sourceId = null;
 
-        if ( typeof style.source != 'string' ) {
+        if (typeof style.source != 'string') {
 
           sourceId = style.id + '_source';
-         
-          this.addSource( sourceId, style.source );
+
+          this.addSource(sourceId, style.source);
 
         } else {
 
@@ -3267,9 +3003,9 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
         }
 
-        const line = new com.mapbox.mapboxsdk.style.layers.LineLayer( style.id, sourceId );
+        const line = new com.mapbox.mapboxsdk.style.layers.LineLayer(style.id, sourceId);
 
-        console.log( "Mapbox:addLineLayer(): after LineLayer" );
+        console.log("Mapbox:addLineLayer(): after LineLayer");
 
         let lineProperties = [];
 
@@ -3277,62 +3013,62 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         //
         // NOTE polyline styles have separate paint and layout sections.
 
-        if ( typeof style.paint == 'undefined' ) {
+        if (typeof style.paint == 'undefined') {
 
-          console.log( "Mapbox:addLineLayer(): paint is undefined" );
+          console.log("Mapbox:addLineLayer(): paint is undefined");
 
           lineProperties = [
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor( 'red' ),
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth( new java.lang.Float( 7 ) ),
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineOpacity( new java.lang.Float( 1 ) )
+            com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor('red'),
+            com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth(new java.lang.Float(7)),
+            com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineOpacity(new java.lang.Float(1))
           ];
 
         } else {
 
           // color
 
-          if ( style.paint[ 'line-color' ] ) {
-            lineProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor( style.paint[ 'line-color' ] ) ); 
+          if (style.paint['line-color']) {
+            lineProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineColor(style.paint['line-color']));
           }
 
           // opacity
 
-          if ( style.paint[ 'line-opacity' ] ) {
-            lineProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineOpacity( new java.lang.Float( style.paint[ 'line-opacity' ] ) ) ); 
+          if (style.paint['line-opacity']) {
+            lineProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineOpacity(new java.lang.Float(style.paint['line-opacity'])));
           }
 
-          console.log( "Mapbox:addLineLayer(): after opacity" );
+          console.log("Mapbox:addLineLayer(): after opacity");
 
           // line width
- 
-          if ( style.paint[ 'line-width' ] ) {
-            lineProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth( new java.lang.Float( style.paint[ 'line-width' ] ) ) ); 
+
+          if (style.paint['line-width']) {
+            lineProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineWidth(new java.lang.Float(style.paint['line-width'])));
           }
 
           // line dash array
- 
-          if ( style.paint[ 'line-dash-array' ] ) {
+
+          if (style.paint['line-dash-array']) {
 
             // the line-dash-array requires some handstands to marhall it into a java Float[] type. 
 
-            let dashArray = Array.create( "java.lang.Float", style.paint[ 'line-dash-array' ].length );
+            let dashArray = Array.create("java.lang.Float", style.paint['line-dash-array'].length);
 
-            for ( let i = 0; i < style.paint[ 'line-dash-array' ].length; i++ ) {
-              dashArray[i] = new java.lang.Float( style.paint[ 'line-dash-array' ][i] );
+            for (let i = 0; i < style.paint['line-dash-array'].length; i++) {
+              dashArray[i] = new java.lang.Float(style.paint['line-dash-array'][i]);
             }
 
-            lineProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineDasharray( dashArray ) ); 
+            lineProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineDasharray(dashArray));
           }
 
         } // end of paint section.
 
         // now the layout section
 
-        if ( typeof style.layout == 'undefined' ) {
+        if (typeof style.layout == 'undefined') {
 
           lineProperties = [
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineCap( com.mapbox.mapboxsdk.style.layers.PropertyFactory.LINE_CAP_ROUND ),
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin( com.mapbox.mapboxsdk.style.layers.PropertyFactory.LINE_JOIN_ROUND )
+            com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineCap(com.mapbox.mapboxsdk.style.layers.PropertyFactory.LINE_CAP_ROUND),
+            com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin(com.mapbox.mapboxsdk.style.layers.PropertyFactory.LINE_JOIN_ROUND)
           ];
 
         } else {
@@ -3341,81 +3077,67 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           //
           // FIXME: Add other styles.
 
-          if ( style.layout[ 'line-cap' ] ) {
+          if (style.layout['line-cap']) {
 
-            let property : any;
+            let property: any;
 
-            switch( style.layout[ 'line-cap' ] ) {
+            switch (style.layout['line-cap']) {
 
               case 'round':
 
                 property = com.mapbox.mapboxsdk.style.layers.PropertyFactory.LINE_CAP_ROUND;
 
-              break;
+                break;
 
               case 'square':
 
                 property = com.mapbox.mapboxsdk.style.layers.PropertyFactory.LINE_CAP_SQUARE;
 
-              break;
+                break;
 
             }
 
-            lineProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineCap( property )); 
+            lineProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineCap(property));
 
           }
 
           // line join.
 
-          if ( style.layout[ 'line-join' ] ) {
+          if (style.layout['line-join']) {
 
-            let property : any;
+            let property: any;
 
-            switch( style.layout[ 'line-join' ] ) {
+            switch (style.layout['line-join']) {
 
               case 'round':
 
                 property = com.mapbox.mapboxsdk.style.layers.PropertyFactory.LINE_JOIN_ROUND;
 
-              break;
+                break;
 
               case 'square':
 
                 property = com.mapbox.mapboxsdk.style.layers.PropertyFactory.LINE_JOIN_SQUARE;
 
-              break;
+                break;
 
             }
 
-            lineProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin( property )); 
+            lineProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.lineJoin(property));
 
           }
 
         } // end of else there was a layout section.
 
-        line.setProperties( lineProperties );
+        line.setProperties(lineProperties);
 
-        this._mapboxMapInstance.getStyle().addLayer( line );
+        this._mapboxMapInstance.getStyle().addLayer(line);
 
-        // In support for clickable GeoJSON features.
-        //
-        // FIXME: for the moment, because I have not been able to figure out how to pull the geometry
-        // from the source, we keep a reference to the feature so we can draw the clickable line when
-        // a click handler is added. This is only supported on GeoJSON features.
-        //
-        // see addSource()
-
-        let lineEntry = this.lines.find( ( entry ) => { return entry.id == sourceId; });
-
-        if ( lineEntry ) {
-          lineEntry.layer = line;
-        }
-
-        console.log( "Mapbox:addLineLayer(): after addLayer" );
+        console.log("Mapbox:addLineLayer(): after addLayer");
 
         resolve();
       } catch (ex) {
-        console.log( "Mapbox:addLineLayer() Error : " + ex);
+        console.log("Mapbox:addLineLayer() Error : " + ex);
         reject(ex);
       }
 
@@ -3440,62 +3162,63 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @todo this does not update the invisible clickable overlay.
   */
 
-  public addLinePoint( id : string, lnglat, nativeMapView? ) : Promise<any> {
+  public addLinePoint(id: string, lnglat, nativeMapView?): Promise<any> {
 
     return new Promise((resolve, reject) => {
-      try {
+      // try {
+      resolve();
 
-        // This only works for GeoJSON features.
-        //
-        // The original thought was to query the source to get the points that make up the line
-        // and then add a point to it. Unfortunately, it seems that the points in the source
-        // are modified and do not match the original set of points that make up the map. I kept
-        // adding a LineString and after querying it it would be returned as a MultiLineString
-        // with more points. 
-        //
-        // As a result of this, we keep the original feature in the lines list and use that
-        // as the data source for the line. As each point is added, we append it to the 
-        // feature and reset the json source for the displayed line. 
+      //   // This only works for GeoJSON features.
+      //   //
+      //   // The original thought was to query the source to get the points that make up the line
+      //   // and then add a point to it. Unfortunately, it seems that the points in the source
+      //   // are modified and do not match the original set of points that make up the map. I kept
+      //   // adding a LineString and after querying it it would be returned as a MultiLineString
+      //   // with more points. 
+      //   //
+      //   // As a result of this, we keep the original feature in the lines list and use that
+      //   // as the data source for the line. As each point is added, we append it to the 
+      //   // feature and reset the json source for the displayed line. 
 
-        let lineEntry = this.lines.find( ( entry ) => { return entry.id == id; });
+      //   let lineEntry = this.lines.find((entry) => { return entry.id == id; });
 
-        if ( ! lineEntry ) {
-          reject( "No such line layer '" + id + "'" );
-          return;
-        }
+      //   if (!lineEntry) {
+      //     reject("No such line layer '" + id + "'");
+      //     return;
+      //   }
 
-        let geometry = lineEntry.feature.geometry();
+      //   let geometry = lineEntry.feature.geometry();
 
-        let coordinates = geometry.coordinates();
+      //   let coordinates = geometry.coordinates();
 
-        console.log( "Mapbox:addLinePoint(): adding point:", lnglat );
+      //   console.log("Mapbox:addLinePoint(): adding point:", lnglat);
 
-        // see https://docs.oracle.com/javase/8/docs/api/java/util/List.html
+      //   // see https://docs.oracle.com/javase/8/docs/api/java/util/List.html
 
-        let newPoint = com.mapbox.geojson.Point.fromLngLat( lnglat[ 0 ], lnglat[ 1 ] );
+      //   let newPoint = com.mapbox.geojson.Point.fromLngLat(lnglat[0], lnglat[1]);
 
-        console.log( "Mapbox:addLinePoint(): newPoint is:", newPoint );
+      //   console.log("Mapbox:addLinePoint(): newPoint is:", newPoint);
 
-        geometry.coordinates().add( newPoint );
+      //   geometry.coordinates().add(newPoint);
 
-        // sadly it appears we have to recreate the feature. The old feature should get 
-        // culled by garbage collection.
+      //   // sadly it appears we have to recreate the feature. The old feature should get 
+      //   // culled by garbage collection.
 
-        lineEntry.feature = com.mapbox.geojson.Feature.fromGeometry( geometry );
+      //   lineEntry.feature = com.mapbox.geojson.Feature.fromGeometry(geometry);
 
-        // now reset the source
+      //   // now reset the source
 
-        let lineSource = this._mapboxMapInstance.getStyle().getSource( id + '_source' );
+      //   let lineSource = this._mapboxMapInstance.getStyle().getSource(id + '_source');
 
-        lineSource.setGeoJson( lineEntry.feature );
+      //   lineSource.setGeoJson(lineEntry.feature);
 
-        console.log( "Mapbox:addLinePoint(): after updating lineSource feature");
+      //   console.log("Mapbox:addLinePoint(): after updating lineSource feature");
 
-        resolve();
-      } catch (ex) {
-        console.log( "Mapbox:addLinePoint() Error : " + ex);
-        reject(ex);
-      }
+      //   resolve();
+      // } catch (ex) {
+      //   console.log("Mapbox:addLinePoint() Error : " + ex);
+      //   reject(ex);
+      // }
     });
 
   } // end of addLinePoint()
@@ -3559,24 +3282,24 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @param {object} nativeMap view.
   */
 
-  private addCircleLayer( style, nativeMapViewInstance? ): Promise<any> {
+  private addCircleLayer(style, nativeMapViewInstance?): Promise<any> {
 
     return new Promise((resolve, reject) => {
       try {
 
-        if ( style.type != 'circle' ) {
-          reject( "Non circle style passed to addCircle()" );
+        if (style.type != 'circle') {
+          reject("Non circle style passed to addCircle()");
         }
 
         // the source may be of type geojson or it may be the id of a source added by addSource().
 
         let sourceId = null;
 
-        if ( typeof style.source != 'string' ) {
+        if (typeof style.source != 'string') {
 
           sourceId = style.id + '_source';
-         
-          this.addSource( sourceId, style.source );
+
+          this.addSource(sourceId, style.source);
 
         } else {
 
@@ -3584,9 +3307,10 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
         }
 
-        const circle = new com.mapbox.mapboxsdk.style.layers.CircleLayer( style.id, sourceId );
+        const circle = new com.mapbox.mapboxsdk.style.layers.CircleLayer(style.id, sourceId);
+        circle.setSourceLayer(sourceId);
 
-        console.log( "Mapbox:addCircleLayer(): after CircleLayer" );
+        console.log("Mapbox:addCircleLayer(): after CircleLayer");
 
         // This took ages to figure out.
         //
@@ -3603,128 +3327,103 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         // to find any documentation to support this. I figured this out over hours of trial and error.
         //
         // https://docs.mapbox.com/mapbox-gl-js/style-spec/#expressions-interpolate
-
         let circleProperties = [];
 
         // some defaults if there's no paint property to the style 
 
-        if ( typeof style.paint == 'undefined' ) {
+        if (typeof style.paint == 'undefined') {
 
-          console.log( "Mapbox:addCircle(): paint is undefined" );
+          console.log("Mapbox:addCircle(): paint is undefined");
 
           circleProperties = [
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor( 'red' ),
+            com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor('red'),
             com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius(
               com.mapbox.mapboxsdk.style.expressions.Expression.interpolate(
-                com.mapbox.mapboxsdk.style.expressions.Expression.exponential( 
-                  new java.lang.Float( 2.0 ) ),
-                  com.mapbox.mapboxsdk.style.expressions.Expression.zoom(),
-                  [
-                    com.mapbox.mapboxsdk.style.expressions.Expression.stop( new java.lang.Float( 0 ), new java.lang.Float( 0 ) ),
-                    com.mapbox.mapboxsdk.style.expressions.Expression.stop( new java.lang.Float( 20 ), new java.lang.Float( 6000 ) )
-                  ]
+                com.mapbox.mapboxsdk.style.expressions.Expression.exponential(
+                  new java.lang.Float(2.0)),
+                com.mapbox.mapboxsdk.style.expressions.Expression.zoom(),
+                [
+                  com.mapbox.mapboxsdk.style.expressions.Expression.stop(new java.lang.Float(0), new java.lang.Float(0)),
+                  com.mapbox.mapboxsdk.style.expressions.Expression.stop(new java.lang.Float(20), new java.lang.Float(6000))
+                ]
               )
             ),
-            com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleBlur(new java.lang.Float( 0.2 ))
+            com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleBlur(new java.lang.Float(0.2))
           ];
 
 
         } else {
 
+          // all style.paint properties can be provided using json arrays,
+          // see https://docs.mapbox.com/mapbox-gl-js/style-spec/expressions/ 
+
           // color
 
-          if ( style.paint[ 'circle-color' ] ) {
-            circleProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor( style.paint[ 'circle-color' ] ) ); 
+          if (style.paint['circle-color']) {
+            if (Array.isArray(style.paint['circle-color'])) {
+              const expression = this.convertGeoJsonToExpression(style.paint['circle-color'])
+              circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor(expression));
+            } else {
+              circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor(style.paint['circle-color']));
+            }
           }
 
           // opacity
 
-          if ( style.paint[ 'circle-opacity' ] ) {
-            circleProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleOpacity( new java.lang.Float( style.paint[ 'circle-opacity' ] ) ) ); 
+          if (style.paint['circle-opacity']) {
+            if (Array.isArray(style.paint['circle-opacity'])) {
+              const expression = this.convertGeoJsonToExpression(style.paint['circle-opacity'])
+              circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleOpacity(expression));
+            } else {
+              circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleOpacity(new java.lang.Float(style.paint['circle-opacity'])));
+            }
           }
 
-          console.log( "Mapbox:addCircle(): after opactiy" );
+          console.log("Mapbox:addCircle(): after opactiy");
 
           // stroke width
- 
-          if ( style.paint[ 'circle-stroke-width' ] ) {
-            circleProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeWidth( new java.lang.Float( style.paint[ 'circle-stroke-width' ] ) ) ); 
+
+          if (style.paint['circle-stroke-width']) {
+            if (Array.isArray(style.paint['circle-stroke-width'])) {
+              const expression = this.convertGeoJsonToExpression(style.paint['circle-stroke-width'])
+              circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeWidth(expression));
+            } else {
+              circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeWidth(new java.lang.Float(style.paint['circle-stroke-width'])));
+            }
           }
 
           // stroke color
 
-          if ( style.paint[ 'circle-stroke-color' ] ) {
-            circleProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeColor( style.paint[ 'circle-stroke-color' ] ) ); 
+          if (style.paint['circle-stroke-color']) {
+            if (Array.isArray(style.paint['circle-stroke-color'])) {
+              const expression = this.convertGeoJsonToExpression(style.paint['circle-stroke-color'])
+              circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeColor(expression));
+            } else {
+              circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleStrokeColor(style.paint['circle-stroke-color']));
+            }
           }
 
-          if ( ! style.paint[ 'circle-radius' ] ) {
-
+          if (!style.paint['circle-radius']) {
             // some default so something will show up on the map. 
-
-            circleProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius( new java.lang.Float( 30 ) )); 
-
+            circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius(new java.lang.Float(30)));
           } else {
-
             // we have two options for a radius. We might have a fixed float or an expression 
-
-            if ( typeof style.paint[ 'circle-radius' ] == 'number' ) {
-              circleProperties.push( com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius( new java.lang.Float( style.paint.radius ) )); 
+            if (Array.isArray(style.paint['circle-radius'])) {
+              const expression = this.convertGeoJsonToExpression(style.paint['circle-radius'])
+              circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius(expression));
             } else {
-
-              if ( ! style.paint[ 'circle-radius' ].stops ) {
-                reject( "No radius or stops provided to addCircleLayer." );
-              }
-
-              // for the moment we assume we have a set of stops and a base. 
-
-              let stopArgs = [];
-
-              console.log( "Mapbox:addCircleLayer(): adding '" + style.paint[ 'circle-radius' ].stops.length + "' stops" );
-
-              for ( let i = 0; i < style.paint[ 'circle-radius' ].stops.length; i++ ) {
-                let stop = style.paint[ 'circle-radius' ].stops[ i ];
-                stopArgs.push( com.mapbox.mapboxsdk.style.expressions.Expression.stop( new java.lang.Float( stop[0] ), new java.lang.Float( stop[ 1 ] )));
-              }
-
-              let base = 2;
-
-              if ( style.paint[ 'circle-radius' ].stops.base ) {
-                base = style.paint[ 'circle-radius' ].stops.base;
-              }
-
-              console.log( "Mapbox:addCircleLayer(): pushing circleRadius with base:", base );
-
-              circleProperties.push( 
-                com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius(
-                  com.mapbox.mapboxsdk.style.expressions.Expression.interpolate(
-                    com.mapbox.mapboxsdk.style.expressions.Expression.exponential( 
-                      new java.lang.Float( base )
-                    ),
-                    com.mapbox.mapboxsdk.style.expressions.Expression.zoom(),
-                    stopArgs
-                  )
-                )
-              );
-            } // end of else we do not have a numeric circle radius
+              circleProperties.push(com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius(new java.lang.Float(style.paint.radius)));
+            }
           } // end of else we have a circle-radius
         }
 
-        circle.setProperties( circleProperties );
+        circle.setProperties(circleProperties);
 
-        this._mapboxMapInstance.getStyle().addLayer( circle );
+        this._mapboxMapInstance.getStyle().addLayer(circle);
 
-        console.log( "Mapbox:addCircleLayer(): added circle layer" );
+        console.log("Mapbox:addCircleLayer(): added circle layer");
 
-        // In support for clickable GeoJSON features.
-
-        let circleEntry = this.circles.find( ( entry ) => { return entry.id == sourceId; });
-
-        if ( circleEntry ) {
-          circleEntry.radius = style[ 'circle-radius' ];
-          circleEntry.layer = circle;
-        }
-
-        console.log( "Mapbox:addCircleLayer(): after addLayer" );
+        console.log("Mapbox:addCircleLayer(): after addLayer");
 
         resolve();
       } catch (ex) {
@@ -3735,6 +3434,12 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   } // end of addCircleLayer()
 
+  convertGeoJsonToExpression(geoJson: any[]) {
+    const jsonArray = new com.google.gson.JsonParser().parse(JSON.stringify(geoJson)).getAsJsonArray();
+    const expression = com.mapbox.mapboxsdk.style.expressions.Expression.Converter.convert(jsonArray);
+    return expression;
+  }
+
   // ----------------------------------------
 
   addGeoJsonClustered(options: AddGeoJsonClusteredOptions, nativeMap?): Promise<any> {
@@ -3742,13 +3447,13 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
       try {
 
         this._mapboxMapInstance.getStyle().addSource(
-            new com.mapbox.mapboxsdk.style.sources.GeoJsonSource(options.name,
-                new java.net.URL(options.data),
-                new com.mapbox.mapboxsdk.style.sources.GeoJsonOptions()
-                    .withCluster(true)
-                    .withClusterMaxZoom(options.clusterMaxZoom || 13)
-                    .withClusterRadius(options.clusterRadius || 40)
-            )
+          new com.mapbox.mapboxsdk.style.sources.GeoJsonSource(options.name,
+            new java.net.URL(options.data),
+            new com.mapbox.mapboxsdk.style.sources.GeoJsonOptions()
+              .withCluster(true)
+              .withClusterMaxZoom(options.clusterMaxZoom || 13)
+              .withClusterRadius(options.clusterRadius || 40)
+          )
         );
 
         const layers = [];
@@ -3777,22 +3482,22 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           // Add some nice circles
           const circles = new com.mapbox.mapboxsdk.style.layers.CircleLayer("cluster-" + i, options.name);
           circles.setProperties([
-                // com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage("icon")
-                com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor(layers[i][1]),
-                com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius(new java.lang.Float(22.0)),
-                com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleBlur(new java.lang.Float(0.2))
-              ]
+            // com.mapbox.mapboxsdk.style.layers.PropertyFactory.iconImage("icon")
+            com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleColor(layers[i][1]),
+            com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleRadius(new java.lang.Float(22.0)),
+            com.mapbox.mapboxsdk.style.layers.PropertyFactory.circleBlur(new java.lang.Float(0.2))
+          ]
           );
 
           const pointCount = com.mapbox.mapboxsdk.style.expressions.Expression.toNumber(com.mapbox.mapboxsdk.style.expressions.Expression.get("point_count"));
 
           circles.setFilter(
-              i === 0 ?
-                  com.mapbox.mapboxsdk.style.expressions.Expression.gte(pointCount, com.mapbox.mapboxsdk.style.expressions.Expression.literal(java.lang.Integer.valueOf(layers[i][0]))) :
-                  com.mapbox.mapboxsdk.style.expressions.Expression.all([
-                    com.mapbox.mapboxsdk.style.expressions.Expression.gte(pointCount, com.mapbox.mapboxsdk.style.expressions.Expression.literal(java.lang.Integer.valueOf(layers[i][0]))),
-                    com.mapbox.mapboxsdk.style.expressions.Expression.lt(pointCount, com.mapbox.mapboxsdk.style.expressions.Expression.literal(java.lang.Integer.valueOf(layers[i - 1][0])))
-                  ])
+            i === 0 ?
+              com.mapbox.mapboxsdk.style.expressions.Expression.gte(pointCount, com.mapbox.mapboxsdk.style.expressions.Expression.literal(java.lang.Integer.valueOf(layers[i][0]))) :
+              com.mapbox.mapboxsdk.style.expressions.Expression.all([
+                com.mapbox.mapboxsdk.style.expressions.Expression.gte(pointCount, com.mapbox.mapboxsdk.style.expressions.Expression.literal(java.lang.Integer.valueOf(layers[i][0]))),
+                com.mapbox.mapboxsdk.style.expressions.Expression.lt(pointCount, com.mapbox.mapboxsdk.style.expressions.Expression.literal(java.lang.Integer.valueOf(layers[i - 1][0])))
+              ])
           );
 
           this._mapboxMapInstance.getStyle().addLayer(circles); // , "building");
@@ -3801,10 +3506,10 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
         // Add the count labels (note that this doesn't show.. #sad)
         const count = new com.mapbox.mapboxsdk.style.layers.SymbolLayer("count", options.name);
         count.setProperties([
-              com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField(com.mapbox.mapboxsdk.style.expressions.Expression.get("point_count")),
-              com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize(new java.lang.Float(12.0)),
-              com.mapbox.mapboxsdk.style.layers.PropertyFactory.textColor(new Color("white").android)
-            ]
+          com.mapbox.mapboxsdk.style.layers.PropertyFactory.textField(com.mapbox.mapboxsdk.style.expressions.Expression.get("point_count")),
+          com.mapbox.mapboxsdk.style.layers.PropertyFactory.textSize(new java.lang.Float(12.0)),
+          com.mapbox.mapboxsdk.style.layers.PropertyFactory.textColor(new Color("white").android)
+        ]
         );
         this._mapboxMapInstance.getStyle().addLayer(count);
 
@@ -3822,25 +3527,25 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * constantly center the map on the users location.
   */
 
-  trackUser( options: TrackUserOptions, nativeMap? ): Promise<void> {
+  trackUser(options: TrackUserOptions, nativeMap?): Promise<void> {
 
-    console.log( "Mapbox::trackUser(): top" );
+    console.log("Mapbox::trackUser(): top");
 
     return new Promise((resolve, reject) => {
       try {
 
-        if (! this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
 
-        this.requestFineLocationPermission().then( () => {
+        this.requestFineLocationPermission().then(() => {
           this.showUserLocationMarker({
             useDefaultLocationEngine: true
           });
 
-        }).catch(err => { 
-          console.error( "Location permission denied. error:", err );
+        }).catch(err => {
+          console.error("Location permission denied. error:", err);
         });
 
         resolve();
@@ -3868,15 +3573,15 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   // --------------------------------------------------------------------------------
 
-  _getMapStyle( input: any ): any { 
+  _getMapStyle(input: any): any {
 
-    console.log( "_getMapStyle(): top with input:", input );
+    console.log("_getMapStyle(): top with input:", input);
 
     // This changed in Mapbox GL Android 7.0.0
 
     const Style = com.mapbox.mapboxsdk.maps.Style;
 
-    console.log( "_getMapStyle(): Style object is:", Style );
+    console.log("_getMapStyle(): Style object is:", Style);
 
     // allow for a style URL to be passed
 
@@ -3917,7 +3622,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @link https://docs.mapbox.com/android/api/map-sdk/7.1.2/com/mapbox/mapboxsdk/maps/MapboxMapOptions.html
   */
 
-  _getMapboxMapOptions( settings ) {
+  _getMapboxMapOptions(settings) {
 
     const mapboxMapOptions = new com.mapbox.mapboxsdk.maps.MapboxMapOptions()
       .compassEnabled(!settings.hideCompass)
@@ -3939,8 +3644,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
     if (settings.center && settings.center.lat && settings.center.lng) {
       const cameraPositionBuilder = new com.mapbox.mapboxsdk.camera.CameraPosition.Builder()
-          .zoom(settings.zoomLevel)
-          .target(new com.mapbox.mapboxsdk.geometry.LatLng(settings.center.lat, settings.center.lng));
+        .zoom(settings.zoomLevel)
+        .target(new com.mapbox.mapboxsdk.geometry.LatLng(settings.center.lat, settings.center.lng));
       mapboxMapOptions.camera(cameraPositionBuilder.build());
     }
 
@@ -3956,11 +3661,11 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @link https://docs.mapbox.com/android/api/map-sdk/8.1.0/com/mapbox/mapboxsdk/location/modes/CameraMode.html
   */
 
-  _stringToCameraMode( mode: UserLocationCameraMode ): any {
+  _stringToCameraMode(mode: UserLocationCameraMode): any {
 
     const modeRef = com.mapbox.mapboxsdk.location.modes.CameraMode;
- 
-    switch( mode ) {
+
+    switch (mode) {
 
       case "NONE":
         return modeRef.NONE;
@@ -3992,23 +3697,23 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * convert string to render mode
   */
 
-  _stringToRenderMode( mode ): any {
+  _stringToRenderMode(mode): any {
 
     let renderMode: any;
 
-    switch( mode ) {
+    switch (mode) {
 
       case 'NORMAL':
         renderMode = com.mapbox.mapboxsdk.location.modes.RenderMode.NORMAL;
-      break;
+        break;
 
       case 'COMPASS':
         renderMode = com.mapbox.mapboxsdk.location.modes.RenderMode.COMPASS;
-      break;
+        break;
 
       case 'GPS':
         renderMode = com.mapbox.mapboxsdk.location.modes.RenderMode.GPS;
-      break;
+        break;
 
     }
 
@@ -4022,7 +3727,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     let hasPermission = android.os.Build.VERSION.SDK_INT < 23; // Android M. (6.0)
 
     if (!hasPermission) {
-      hasPermission = com.mapbox.android.core.permissions.PermissionsManager.areLocationPermissionsGranted( application.android.context );
+      hasPermission = com.mapbox.android.core.permissions.PermissionsManager.areLocationPermissionsGranted(application.android.context);
     }
 
     return hasPermission;
@@ -4030,7 +3735,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   // -------------------------------------------------------------
 
-  _getRegionName( offlineRegion ) {
+  _getRegionName(offlineRegion) {
     const metadata = offlineRegion.getMetadata();
     const jsonStr = new java.lang.String(metadata, "UTF-8");
     const jsonObj = new org.json.JSONObject(jsonStr);
@@ -4063,107 +3768,107 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @todo at least with simulated data, the location is only updated once hence adding support for forceLocation method.
   */
 
-  showUserLocationMarker( options: any, nativeMap? ) : Promise<void> {
+  showUserLocationMarker(options: any, nativeMap?): Promise<void> {
 
     return new Promise((resolve, reject) => {
       try {
 
-        console.log( "Mapbox::showUserLocationMarker(): top" );
+        console.log("Mapbox::showUserLocationMarker(): top");
 
-        if (! this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
 
-        if ( ! com.mapbox.android.core.permissions.PermissionsManager.areLocationPermissionsGranted( application.android.context ) ) {
+        if (!com.mapbox.android.core.permissions.PermissionsManager.areLocationPermissionsGranted(application.android.context)) {
 
-          console.log( "Mapbox::showUserLocationMarker(): location permissions are not granted." );
+          console.log("Mapbox::showUserLocationMarker(): location permissions are not granted.");
 
-          reject( "Location permissions not granted." );
+          reject("Location permissions not granted.");
           return;
-        } 
-
-        let componentOptionsBuilder = com.mapbox.mapboxsdk.location.LocationComponentOptions.builder( application.android.context );
-
-        if ( typeof options.elevation != 'undefined' ) {
-          componentOptionsBuilder.elevation( new java.lang.Float( options.elevation ));
         }
 
-        if ( typeof options.accuracyColor != 'undefined' ) {
-          componentOptionsBuilder.accuracyColor( android.graphics.Color.parseColor( options.accuracyColor ))
+        let componentOptionsBuilder = com.mapbox.mapboxsdk.location.LocationComponentOptions.builder(application.android.context);
+
+        if (typeof options.elevation != 'undefined') {
+          componentOptionsBuilder.elevation(new java.lang.Float(options.elevation));
         }
-         
-        if ( typeof options.accuracyAlpha != 'undefined' ) {
-          componentOptionsBuilder.accuracyAlpha( new java.lang.Float( options.accuracyAlpha ));
+
+        if (typeof options.accuracyColor != 'undefined') {
+          componentOptionsBuilder.accuracyColor(android.graphics.Color.parseColor(options.accuracyColor))
+        }
+
+        if (typeof options.accuracyAlpha != 'undefined') {
+          componentOptionsBuilder.accuracyAlpha(new java.lang.Float(options.accuracyAlpha));
         }
 
         let componentOptions = componentOptionsBuilder.build();
 
-        console.log( "Mapbox::showUserLocationMarker(): after componentOptions.build()" );
+        console.log("Mapbox::showUserLocationMarker(): after componentOptions.build()");
 
         this._locationComponent = this._mapboxMapInstance.getLocationComponent();
 
-        console.log( "Mapbox::showUserLocationMarker(): after getLocationComponent" );
+        console.log("Mapbox::showUserLocationMarker(): after getLocationComponent");
 
-        let activationOptionsBuilder = com.mapbox.mapboxsdk.location.LocationComponentActivationOptions.builder( application.android.context, this._mapboxMapInstance.getStyle() );
+        let activationOptionsBuilder = com.mapbox.mapboxsdk.location.LocationComponentActivationOptions.builder(application.android.context, this._mapboxMapInstance.getStyle());
 
-        console.log( "Mapbox::showUserLocationMarker(): after activationOptionsBuilder" );
+        console.log("Mapbox::showUserLocationMarker(): after activationOptionsBuilder");
 
-        activationOptionsBuilder.locationComponentOptions( componentOptions );
+        activationOptionsBuilder.locationComponentOptions(componentOptions);
 
         let useDefaultEngine = true;
 
-        if ( typeof options.useDefaultLocationEngine != 'undefined' ) {
+        if (typeof options.useDefaultLocationEngine != 'undefined') {
           useDefaultEngine = options.useDefaultLocationEngine;
         }
 
-        console.log( "Mapbox::showUserLocationMarker(): before useDefaultEngine" );
+        console.log("Mapbox::showUserLocationMarker(): before useDefaultEngine");
 
-        activationOptionsBuilder.useDefaultLocationEngine( useDefaultEngine );
+        activationOptionsBuilder.useDefaultLocationEngine(useDefaultEngine);
 
-        console.log( "Mapbox::showUserLocationMarker(): after useDefaultEngine" );
+        console.log("Mapbox::showUserLocationMarker(): after useDefaultEngine");
 
-        let locationComponentActivationOptions = activationOptionsBuilder.build(); 
+        let locationComponentActivationOptions = activationOptionsBuilder.build();
 
-        console.log( "Mapbox::showUserLocationMarker(): after ActivationOptions" );
+        console.log("Mapbox::showUserLocationMarker(): after ActivationOptions");
 
-        this._locationComponent.activateLocationComponent( locationComponentActivationOptions );
-        this._locationComponent.setLocationComponentEnabled( true );
+        this._locationComponent.activateLocationComponent(locationComponentActivationOptions);
+        this._locationComponent.setLocationComponentEnabled(true);
 
-        let cameraMode = this._stringToCameraMode( 'TRACKING' );
+        let cameraMode = this._stringToCameraMode('TRACKING');
 
-        if ( typeof options.cameraMode != 'undefined' ) {
-          cameraMode = this._stringToCameraMode( options.cameraMode );
+        if (typeof options.cameraMode != 'undefined') {
+          cameraMode = this._stringToCameraMode(options.cameraMode);
         }
 
-        this._locationComponent.setCameraMode( cameraMode );
+        this._locationComponent.setCameraMode(cameraMode);
 
         let renderMode = com.mapbox.mapboxsdk.location.modes.RenderMode.COMPASS;
 
-        if ( typeof options.renderMode != 'undefined' ) {
-          renderMode = this._stringToRenderMode( options.renderMode );
+        if (typeof options.renderMode != 'undefined') {
+          renderMode = this._stringToRenderMode(options.renderMode);
         }
 
-        this._locationComponent.setRenderMode( renderMode );
+        this._locationComponent.setRenderMode(renderMode);
 
-        console.log( "Mapbox::showUserLocationMarker(): after renderMode" );
+        console.log("Mapbox::showUserLocationMarker(): after renderMode");
 
-        if ( typeof options.clickListener != 'undefined' ) {
- 
+        if (typeof options.clickListener != 'undefined') {
+
           this.onLocationClickListener = new com.mapbox.mapboxsdk.location.OnLocationClickListener({
-            onLocationComponentClick: ( component ) => { 
-              options.clickListener( component );
+            onLocationComponentClick: (component) => {
+              options.clickListener(component);
             }
           });
 
-          this._locationComponent.addOnLocationClickListener( this.onLocationClickListener );
+          this._locationComponent.addOnLocationClickListener(this.onLocationClickListener);
 
-          this.gcFix( 'com.mapbox.mapboxsdk.location.OnLocationClickListener', this.onLocationClickListener );
+          this.gcFix('com.mapbox.mapboxsdk.location.OnLocationClickListener', this.onLocationClickListener);
 
         }
 
-        if ( typeof options.cameraTrackingChangedListener != 'undefined' ) {
-          this._locationComponent.addOnCameraTrackingChangedListener( options.cameraTrackingChangedListener );
+        if (typeof options.cameraTrackingChangedListener != 'undefined') {
+          this._locationComponent.addOnCameraTrackingChangedListener(options.cameraTrackingChangedListener);
         }
 
         resolve();
@@ -4183,27 +3888,27 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * This method destroys the user location marker. 
   */
 
-  hideUserLocationMarker( nativeMap? ) : Promise<void> {
+  hideUserLocationMarker(nativeMap?): Promise<void> {
 
     return new Promise((resolve, reject) => {
       try {
 
-        console.log( "Mapbox::hideUserLocationMarker(): top" );
+        console.log("Mapbox::hideUserLocationMarker(): top");
 
-        if (! this._mapboxMapInstance ) {
+        if (!this._mapboxMapInstance) {
           reject("No map has been loaded");
           return;
         }
 
-        if ( ! this._locationComponent ) {
+        if (!this._locationComponent) {
 
-          console.log( "Mapbox::hideUserLocationMarker(): no location component is loaded." );
+          console.log("Mapbox::hideUserLocationMarker(): no location component is loaded.");
 
           resolve();
           return;
         }
 
-        this._locationComponent.setLocationComponentEnabled( false );
+        this._locationComponent.setLocationComponentEnabled(false);
 
         resolve();
 
@@ -4229,27 +3934,27 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * can called.
   */
 
-  changeUserLocationMarkerMode( renderModeString, cameraModeString : UserLocationCameraMode, nativeMap? ) : Promise<any> {
+  changeUserLocationMarkerMode(renderModeString, cameraModeString: UserLocationCameraMode, nativeMap?): Promise<any> {
 
     return new Promise((resolve, reject) => {
       try {
 
-        if ( ! this._locationComponent ) {
-          reject( "No location component has been loaded");
+        if (!this._locationComponent) {
+          reject("No location component has been loaded");
           return;
         }
 
-        console.log( "Mapbox::changeUserLocationMarkerMode(): current render mode is:", this._locationComponent.getRenderMode() );
+        console.log("Mapbox::changeUserLocationMarkerMode(): current render mode is:", this._locationComponent.getRenderMode());
 
-        console.log( "Mapbox::changeUserLocationMarkerMode(): changing renderMode to '" + renderModeString + "' cameraMode '" + cameraModeString + "'" );
+        console.log("Mapbox::changeUserLocationMarkerMode(): changing renderMode to '" + renderModeString + "' cameraMode '" + cameraModeString + "'");
 
-        let cameraMode = this._stringToCameraMode( cameraModeString );
-        let renderMode = this._stringToRenderMode( renderModeString );
+        let cameraMode = this._stringToCameraMode(cameraModeString);
+        let renderMode = this._stringToRenderMode(renderModeString);
 
-        this._locationComponent.setCameraMode( cameraMode );
-        this._locationComponent.setRenderMode( renderMode );
+        this._locationComponent.setCameraMode(cameraMode);
+        this._locationComponent.setRenderMode(renderMode);
 
-        console.log( "Mapbox::changeUserLocationMarkerMode(): new render mode is:", this._locationComponent.getRenderMode() );
+        console.log("Mapbox::changeUserLocationMarkerMode(): new render mode is:", this._locationComponent.getRenderMode());
 
       } catch (ex) {
         console.log("Error in mapbox.showUserLocationMarker: " + ex);
@@ -4269,27 +3974,27 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @todo figure out why the user location marker is not updating.
   */
 
-  forceUserLocationUpdate( location: any, nativeMap? ) : Promise<void> {
+  forceUserLocationUpdate(location: any, nativeMap?): Promise<void> {
 
     return new Promise((resolve, reject) => {
       try {
 
-        console.log( "Mapbox::forceUserLocation(): top" );
+        console.log("Mapbox::forceUserLocation(): top");
 
-        if (! this._locationComponent ) {
+        if (!this._locationComponent) {
           reject("No location component has been loaded");
           return;
         }
 
         // the location object needs to be converted into an android location
 
-        let nativeLocation = new android.location.Location( 'background' );
+        let nativeLocation = new android.location.Location('background');
 
-        nativeLocation.setLatitude( location.latitude );
-        nativeLocation.setLongitude( location.longitude );
-        nativeLocation.setAltitude( location.altitude );
+        nativeLocation.setLatitude(location.latitude);
+        nativeLocation.setLongitude(location.longitude);
+        nativeLocation.setAltitude(location.altitude);
 
-        this._locationComponent.forceLocationUpdate( nativeLocation );
+        this._locationComponent.forceLocationUpdate(nativeLocation);
 
         resolve();
       } catch (ex) {
@@ -4299,10 +4004,10 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     })
 
   };
-    
+
   // ---------------------------------------------------------------
 
-  _getClickedMarkerDetails( clicked ) {
+  _getClickedMarkerDetails(clicked) {
     for (let m in this._markers) {
       let cached = this._markers[m];
       // tslint:disable-next-line:triple-equals
@@ -4321,7 +4026,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   // ------------------------------------------------------------
 
-  _downloadImage( marker ) {
+  _downloadImage(marker) {
     return new Promise((resolve, reject) => {
       // to cache..
       if (this._markerIconDownloadCache[marker.icon]) {
@@ -4345,7 +4050,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   // ------------------------------------------------------------
 
-  _downloadMarkerImages( markers ) {
+  _downloadMarkerImages(markers) {
     let iterations = [];
     let result = [];
     for (let i = 0; i < markers.length; i++) {
@@ -4380,24 +4085,24 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
   * @param {object} nativeMap view.
   */
 
-  private addCircleAnnotation( geojson, nativeMapViewInstance? ): Promise<any> {
+  private addCircleAnnotation(geojson, nativeMapViewInstance?): Promise<any> {
 
     return new Promise((resolve, reject) => {
       try {
 
-        console.log( "Mapbox:addCircleAnnotation(): top with geojson:", geojson );
+        console.log("Mapbox:addCircleAnnotation(): top with geojson:", geojson);
 
         // we need a source of type geojson.
 
-        console.log( "Mapbox:addCircleAnnotation(): before addSource with geojson:", geojson );
+        console.log("Mapbox:addCircleAnnotation(): before addSource with geojson:", geojson);
 
-        let geojsonString = JSON.stringify( geojson );
+        let geojsonString = JSON.stringify(geojson);
 
-        let layer = this.circleManager.create( geojsonString );
+        let layer = this.circleManager.create(geojsonString);
 
-        console.log( "Mapbox:addCircleAnnotation(): added circle annotation:", layer );
+        console.log("Mapbox:addCircleAnnotation(): added circle annotation:", layer);
 
-        resolve( layer );
+        resolve(layer);
 
       } catch (ex) {
         console.log("Error in mapbox.addCircleAnnotation: " + ex);
@@ -4409,307 +4114,203 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   // -------------------------------------------------------------------------------------
 
-  /**
-  * add a line annotation
-  *
-  * Draws a line using the new Annotations plugin. 
-  *
-  * NOTE: This is here just for reference.
-  *
-  * The Annotations plugin allows for listening to events on a line which the standard Layer
-  * classes do not.
-  *
-  * However, what sucks is that:
-  *
-  * - Annotations do not provide the range of styling options that a line layer does
-  * - Annotations use a GeoJSON format, where styling is done via a properties child, instead of the Mapbox Style format. 
-  *
-  * {
-  *   "type": "FeatureCollection",
-  *   "features": [{
-  *     "type": "Feature",
-  *     "geometry": {
-  *       "type": "LineString",
-  *       "coordinates": [
-  *         [ -76.947041, 39.007846 ],
-  *         [ 12.5, 41.9 ]
-  *       ]
-  *     },
-  *     "properties": {
-  *       "line-color": "white",
-  *       "line-width": "8",
-  *       "is-draggable": false
-  *     }
-  *   }]
-  * } 
-  *
-  * @param {object} geojson - a GeoJSON feature collection.
-  * @param {any} nativeMapView - native map view (com.mapbox.mapboxsdk.maps.MapView)
-  *
-  * @return {Promise<any>}
-  *
-  * @link https://docs.mapbox.com/android/api/plugins/annotation/0.5.0/com/mapbox/mapboxsdk/plugins/annotation/package-summary.html
-  * @link https://docs.mapbox.com/android/api/map-sdk/7.1.2/com/mapbox/mapboxsdk/maps/Style.html#addSource-com.mapbox.mapboxsdk.style.sources.Source-
-  */
-
-  private addLineAnnotation( geojson, nativeMapViewInstance? ) : Promise<any> {
-
-    return new Promise((resolve, reject) => {
-      try {
-
-        console.log( "Mapbox:addLineAnnotation(): before addSource with geojson:", geojson );
-
-        let geojsonString = JSON.stringify( geojson );
-
-        console.log( "Mapbox:addLineAnnotation(): before create" );
-
-        let line = this.lineManager.create( geojsonString );
-
-        console.log( "Mapbox:addLineAnnotation(): added line annotation:", line );
-
-        resolve( line );
-
-      } catch (ex) {
-        console.log("Error in mapbox.addPolyline: " + ex);
-        reject(ex);
-      }
-    });
-
-  } // end of addLineAnnotation
-
-  // -------------------------------------------------------------------------------------
-
-  private async testLineAnnotation( nativeMapView ) {
-
-    let geojson = {
-      "type": "FeatureCollection",
-      "features": [{
-        "type": "Feature",
-        "geometry": {
-          "type": "LineString",
-          "coordinates": this.getTestCoords()
-        },
-        "properties": {
-          "line-color": "white",
-          "line-width": "8",
-          "line-dash-array": [ 2, 4, 2, 1 ] 
-        }
-      }]
-    }; 
-
-
-    let dashArray = Array.create( "java.lang.Float", geojson.features[0].properties[ 'line-dash-array' ].length );
-
-    for ( let i = 0; i < geojson.features[0].properties[ 'line-dash-array' ].length; i++ ) {
-      dashArray[i] = new java.lang.Float( geojson.features[0].properties[ 'line-dash-array' ][i] );
-    }
-
-    let line = await this.addLineAnnotation( geojson, nativeMapView );
-
-    this.lineManager.setLineDashArray( dashArray );
-
-  }
-
-  // -----------------------------------------------------------------------------------------
-
   getTestCoords() {
-
- return [
-[-76.926164,39.019062],
-[-76.926100,39.019168],
-[-76.926013,39.019257],
-[-76.925905,39.019328],
-[-76.925777,39.019380],
-[-76.925632,39.019408],
-[-76.925481,39.019405],
-[-76.925337,39.019372],
-[-76.925209,39.019313],
-[-76.925104,39.019234],
-[-76.925026,39.019136],
-[-76.925010,39.018851],
-[-76.925054,39.018724],
-[-76.925139,39.018616],
-[-76.925252,39.018528],
-[-76.925387,39.018465],
-[-76.925539,39.018433],
-[-76.925694,39.018422],
-[-76.925857,39.018426],
-[-76.926027,39.018437],
-[-76.927847,39.018652],
-[-76.930178,39.019155],
-[-76.932151,39.019811],
-[-76.934475,39.020730],
-[-76.938543,39.022225],
-[-76.941642,39.022854],
-[-76.944704,39.023275],
-[-76.946380,39.024124],
-[-76.948033,39.025760],
-[-76.948497,39.027019],
-[-76.948306,39.028576],
-[-76.947345,39.030150],
-[-76.945672,39.031692],
-[-76.943317,39.033067],
-[-76.941067,39.034591],
-[-76.938712,39.036849],
-[-76.937134,39.039019],
-[-76.934067,39.043621],
-[-76.931722,39.047206],
-[-76.929912,39.050756],
-[-76.928589,39.053624],
-[-76.927063,39.056683],
-[-76.925731,39.058167],
-[-76.924575,39.059077],
-[-76.922749,39.060070],
-[-76.920061,39.061071],
-[-76.918383,39.061644],
-[-76.915324,39.062765],
-[-76.913071,39.063800],
-[-76.910303,39.065627],
-[-76.908491,39.067117],
-[-76.907337,39.068725],
-[-76.906080,39.071488],
-[-76.905077,39.073318],
-[-76.904587,39.074003],
-[-76.904400,39.074114],
-[-76.904184,39.074189],
-[-76.903946,39.074212],
-[-76.903712,39.074192],
-[-76.903464,39.074145],
-[-76.903301,39.074030],
-[-76.903158,39.073875],
-[-76.903071,39.073696],
-[-76.903039,39.073516],
-[-76.903065,39.073338],
-[-76.903149,39.073168],
-[-76.903282,39.073021],
-[-76.903465,39.072896],
-[-76.903679,39.072819],
-[-76.903903,39.072786],
-[-76.904124,39.072797],
-[-76.904329,39.072851],
-[-76.904518,39.072940],
-[-76.904706,39.073029],
-[-76.904855,39.073158],
-[-76.906221,39.074084],
-[-76.908129,39.074828],
-[-76.910401,39.075078],
-[-76.913482,39.074758],
-[-76.924829,39.073772],
-[-76.930687,39.073591],
-[-76.936115,39.073664],
-[-76.945228,39.074826],
-[-76.948338,39.075918],
-[-76.954834,39.079209],
-[-76.958566,39.081175],
-[-76.962182,39.082907],
-[-76.964617,39.083332],
-[-76.967407,39.083191],
-[-76.969484,39.083412],
-[-76.971742,39.084170],
-[-76.976687,39.086114],
-[-76.983025,39.088788],
-[-76.985704,39.089512],
-[-76.988488,39.089779],
-[-76.991281,39.089590],
-[-76.997539,39.088687],
-[-77.001787,39.088312],
-[-77.008541,39.087897],
-[-77.013845,39.087128],
-[-77.020459,39.085992],
-[-77.023236,39.085835],
-[-77.025211,39.086389],
-[-77.026750,39.087508],
-[-77.027710,39.089008],
-[-77.028146,39.090903],
-[-77.029034,39.093259],
-[-77.030437,39.094859],
-[-77.032618,39.096362],
-[-77.035143,39.097464],
-[-77.038513,39.098369],
-[-77.042130,39.099532],
-[-77.044851,39.100887],
-[-77.047813,39.102913],
-[-77.050996,39.105187],
-[-77.055267,39.108274],
-[-77.058337,39.110646],
-[-77.061623,39.113689],
-[-77.064504,39.115979],
-[-77.066908,39.117065],
-[-77.069589,39.117678],
-[-77.081940,39.120455],
-[-77.087705,39.123085],
-[-77.091849,39.124533],
-[-77.096482,39.125620],
-[-77.101050,39.126210],
-[-77.106463,39.126419],
-[-77.113894,39.126642],
-[-77.118437,39.126990],
-[-77.120607,39.127777],
-[-77.122318,39.129042],
-[-77.124218,39.131225],
-[-77.126393,39.133643],
-[-77.128644,39.135491],
-[-77.131388,39.136958],
-[-77.138116,39.139101],
-[-77.140084,39.138936],
-[-77.141828,39.138163],
-[-77.143102,39.136928],
-[-77.144688,39.135612],
-[-77.146269,39.135118],
-[-77.147972,39.135110],
-[-77.149904,39.135622],
-[-77.155834,39.137330],
-[-77.158453,39.137591],
-[-77.161087,39.137398],
-[-77.163593,39.136765],
-[-77.166115,39.135549],
-[-77.167949,39.134050],
-[-77.171853,39.129988],
-[-77.175581,39.126120],
-[-77.179622,39.122026],
-[-77.180894,39.121131],
-[-77.181190,39.121005],
-[-77.181495,39.120898],
-[-77.181806,39.120804],
-[-77.182127,39.120726],
-[-77.182461,39.120671],
-[-77.182803,39.120637],
-[-77.183148,39.120626],
-[-77.183494,39.120636],
-[-77.183839,39.120665],
-[-77.184182,39.120715],
-[-77.184520,39.120787],
-[-77.184852,39.120878],
-[-77.185494,39.121106],
-[-77.189478,39.122770],
-[-77.191456,39.123177],
-[-77.194133,39.123137],
-[-77.197993,39.123036],
-[-77.198559,39.123151],
-[-77.198828,39.123246],
-[-77.199081,39.123364],
-[-77.199314,39.123501],
-[-77.199519,39.123656],
-[-77.199701,39.123827],
-[-77.199863,39.124012],
-[-77.200012,39.124209],
-[-77.201714,39.126527],
-[-77.203814,39.128927],
-[-77.206368,39.131478],
-[-77.208734,39.134112],
-[-77.210918,39.137302],
-[-77.212660,39.140680],
-[-77.214526,39.145223],
-[-77.215510,39.146948],
-[-77.217811,39.149987],
-[-77.220639,39.152707],
-[-77.224698,39.155944],
-[-77.228768,39.158858],
-[-77.233073,39.161274],
-[-77.237891,39.163827],
-[-77.240401,39.165853],
-[-77.242376,39.168174]
-];
+    return [
+      [-76.926164, 39.019062],
+      [-76.926100, 39.019168],
+      [-76.926013, 39.019257],
+      [-76.925905, 39.019328],
+      [-76.925777, 39.019380],
+      [-76.925632, 39.019408],
+      [-76.925481, 39.019405],
+      [-76.925337, 39.019372],
+      [-76.925209, 39.019313],
+      [-76.925104, 39.019234],
+      [-76.925026, 39.019136],
+      [-76.925010, 39.018851],
+      [-76.925054, 39.018724],
+      [-76.925139, 39.018616],
+      [-76.925252, 39.018528],
+      [-76.925387, 39.018465],
+      [-76.925539, 39.018433],
+      [-76.925694, 39.018422],
+      [-76.925857, 39.018426],
+      [-76.926027, 39.018437],
+      [-76.927847, 39.018652],
+      [-76.930178, 39.019155],
+      [-76.932151, 39.019811],
+      [-76.934475, 39.020730],
+      [-76.938543, 39.022225],
+      [-76.941642, 39.022854],
+      [-76.944704, 39.023275],
+      [-76.946380, 39.024124],
+      [-76.948033, 39.025760],
+      [-76.948497, 39.027019],
+      [-76.948306, 39.028576],
+      [-76.947345, 39.030150],
+      [-76.945672, 39.031692],
+      [-76.943317, 39.033067],
+      [-76.941067, 39.034591],
+      [-76.938712, 39.036849],
+      [-76.937134, 39.039019],
+      [-76.934067, 39.043621],
+      [-76.931722, 39.047206],
+      [-76.929912, 39.050756],
+      [-76.928589, 39.053624],
+      [-76.927063, 39.056683],
+      [-76.925731, 39.058167],
+      [-76.924575, 39.059077],
+      [-76.922749, 39.060070],
+      [-76.920061, 39.061071],
+      [-76.918383, 39.061644],
+      [-76.915324, 39.062765],
+      [-76.913071, 39.063800],
+      [-76.910303, 39.065627],
+      [-76.908491, 39.067117],
+      [-76.907337, 39.068725],
+      [-76.906080, 39.071488],
+      [-76.905077, 39.073318],
+      [-76.904587, 39.074003],
+      [-76.904400, 39.074114],
+      [-76.904184, 39.074189],
+      [-76.903946, 39.074212],
+      [-76.903712, 39.074192],
+      [-76.903464, 39.074145],
+      [-76.903301, 39.074030],
+      [-76.903158, 39.073875],
+      [-76.903071, 39.073696],
+      [-76.903039, 39.073516],
+      [-76.903065, 39.073338],
+      [-76.903149, 39.073168],
+      [-76.903282, 39.073021],
+      [-76.903465, 39.072896],
+      [-76.903679, 39.072819],
+      [-76.903903, 39.072786],
+      [-76.904124, 39.072797],
+      [-76.904329, 39.072851],
+      [-76.904518, 39.072940],
+      [-76.904706, 39.073029],
+      [-76.904855, 39.073158],
+      [-76.906221, 39.074084],
+      [-76.908129, 39.074828],
+      [-76.910401, 39.075078],
+      [-76.913482, 39.074758],
+      [-76.924829, 39.073772],
+      [-76.930687, 39.073591],
+      [-76.936115, 39.073664],
+      [-76.945228, 39.074826],
+      [-76.948338, 39.075918],
+      [-76.954834, 39.079209],
+      [-76.958566, 39.081175],
+      [-76.962182, 39.082907],
+      [-76.964617, 39.083332],
+      [-76.967407, 39.083191],
+      [-76.969484, 39.083412],
+      [-76.971742, 39.084170],
+      [-76.976687, 39.086114],
+      [-76.983025, 39.088788],
+      [-76.985704, 39.089512],
+      [-76.988488, 39.089779],
+      [-76.991281, 39.089590],
+      [-76.997539, 39.088687],
+      [-77.001787, 39.088312],
+      [-77.008541, 39.087897],
+      [-77.013845, 39.087128],
+      [-77.020459, 39.085992],
+      [-77.023236, 39.085835],
+      [-77.025211, 39.086389],
+      [-77.026750, 39.087508],
+      [-77.027710, 39.089008],
+      [-77.028146, 39.090903],
+      [-77.029034, 39.093259],
+      [-77.030437, 39.094859],
+      [-77.032618, 39.096362],
+      [-77.035143, 39.097464],
+      [-77.038513, 39.098369],
+      [-77.042130, 39.099532],
+      [-77.044851, 39.100887],
+      [-77.047813, 39.102913],
+      [-77.050996, 39.105187],
+      [-77.055267, 39.108274],
+      [-77.058337, 39.110646],
+      [-77.061623, 39.113689],
+      [-77.064504, 39.115979],
+      [-77.066908, 39.117065],
+      [-77.069589, 39.117678],
+      [-77.081940, 39.120455],
+      [-77.087705, 39.123085],
+      [-77.091849, 39.124533],
+      [-77.096482, 39.125620],
+      [-77.101050, 39.126210],
+      [-77.106463, 39.126419],
+      [-77.113894, 39.126642],
+      [-77.118437, 39.126990],
+      [-77.120607, 39.127777],
+      [-77.122318, 39.129042],
+      [-77.124218, 39.131225],
+      [-77.126393, 39.133643],
+      [-77.128644, 39.135491],
+      [-77.131388, 39.136958],
+      [-77.138116, 39.139101],
+      [-77.140084, 39.138936],
+      [-77.141828, 39.138163],
+      [-77.143102, 39.136928],
+      [-77.144688, 39.135612],
+      [-77.146269, 39.135118],
+      [-77.147972, 39.135110],
+      [-77.149904, 39.135622],
+      [-77.155834, 39.137330],
+      [-77.158453, 39.137591],
+      [-77.161087, 39.137398],
+      [-77.163593, 39.136765],
+      [-77.166115, 39.135549],
+      [-77.167949, 39.134050],
+      [-77.171853, 39.129988],
+      [-77.175581, 39.126120],
+      [-77.179622, 39.122026],
+      [-77.180894, 39.121131],
+      [-77.181190, 39.121005],
+      [-77.181495, 39.120898],
+      [-77.181806, 39.120804],
+      [-77.182127, 39.120726],
+      [-77.182461, 39.120671],
+      [-77.182803, 39.120637],
+      [-77.183148, 39.120626],
+      [-77.183494, 39.120636],
+      [-77.183839, 39.120665],
+      [-77.184182, 39.120715],
+      [-77.184520, 39.120787],
+      [-77.184852, 39.120878],
+      [-77.185494, 39.121106],
+      [-77.189478, 39.122770],
+      [-77.191456, 39.123177],
+      [-77.194133, 39.123137],
+      [-77.197993, 39.123036],
+      [-77.198559, 39.123151],
+      [-77.198828, 39.123246],
+      [-77.199081, 39.123364],
+      [-77.199314, 39.123501],
+      [-77.199519, 39.123656],
+      [-77.199701, 39.123827],
+      [-77.199863, 39.124012],
+      [-77.200012, 39.124209],
+      [-77.201714, 39.126527],
+      [-77.203814, 39.128927],
+      [-77.206368, 39.131478],
+      [-77.208734, 39.134112],
+      [-77.210918, 39.137302],
+      [-77.212660, 39.140680],
+      [-77.214526, 39.145223],
+      [-77.215510, 39.146948],
+      [-77.217811, 39.149987],
+      [-77.220639, 39.152707],
+      [-77.224698, 39.155944],
+      [-77.228768, 39.158858],
+      [-77.233073, 39.161274],
+      [-77.237891, 39.163827],
+      [-77.240401, 39.165853],
+      [-77.242376, 39.168174]
+    ];
 
   }
 

--- a/src/mapbox.common.ts
+++ b/src/mapbox.common.ts
@@ -568,7 +568,7 @@ export interface MapboxApi {
 
   addLinePoint( id : string, point, nativeMapView? : any ): Promise<any>;
 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions, nativeMap?: any): Promise<Array<Feature>>;
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions, nativeMap?: any): Array<Feature>;
 
   addPolygon(options: AddPolygonOptions, nativeMap?: any): Promise<any>;
 
@@ -580,7 +580,7 @@ export interface MapboxApi {
 
   animateCamera(options: AnimateCameraOptions, nativeMap?: any): Promise<any>;
 
-  setOnMapClickListener(listener: (data: LatLng) => void, nativeMap?): Promise<any>;
+  setOnMapClickListener(listener: (data: LatLng) => boolean, nativeMap?): Promise<any>;
 
   setOnMapLongClickListener(listener: (data: LatLng) => void, nativeMap?): Promise<any>;
 
@@ -697,9 +697,9 @@ export interface MapboxViewApi {
 
   removeMarkers(options?: any): Promise<any>;
 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Promise<Array<Feature>>;
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Array<Feature>;
 
-  setOnMapClickListener(listener: (data: LatLng) => void): Promise<any>;
+  setOnMapClickListener(listener: (data: LatLng) => boolean): Promise<any>;
 
   setOnMapLongClickListener(listener: (data: LatLng) => void): Promise<any>;
 
@@ -755,7 +755,7 @@ export interface MapboxViewApi {
 
   addLinePoint( id : string, point ): Promise<any>;
 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Promise<Array<Feature>>;
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Array<Feature>;
 
   addPolygon(options: AddPolygonOptions): Promise<any>;
 
@@ -841,7 +841,7 @@ export abstract class MapboxViewCommonBase extends ContentView implements Mapbox
 
   // -----------------------------------------------------------------
 
-  setOnMapClickListener(listener: (data: LatLng) => void): Promise<any> {
+  setOnMapClickListener(listener: (data: LatLng) => boolean): Promise<any> {
     return this.mapbox.setOnMapClickListener(listener, this.getNativeMapView());
   }
 
@@ -1007,7 +1007,7 @@ export abstract class MapboxViewCommonBase extends ContentView implements Mapbox
 
   // -----------------------------------------------------------------
 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Promise<Array<Feature>> {
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Array<Feature> {
     return this.mapbox.queryRenderedFeatures(options, this.getNativeMapView());
   }
 

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -1421,14 +1421,12 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   // --------------------------------------------------------------
 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions, nativeMap?): Promise<Array<Feature>> {
-    return new Promise((resolve, reject) => {
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions, nativeMap?): Array<Feature> {
       try {
         const theMap: MGLMapView = nativeMap || this._mapboxViewInstance;
         const point = options.point;
         if (point === undefined) {
-          reject("Please set the 'point' parameter");
-          return;
+          throw new Error("Please set the 'point' parameter");
         }
 
         const {x, y} = theMap.convertCoordinateToPointToView({latitude: point.lat, longitude: point.lng}, theMap);
@@ -1457,12 +1455,11 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           });
         }
 
-        resolve(result);
+        return result;
       } catch (ex) {
         console.log("Error in mapbox.queryRenderedFeatures: " + ex);
-        reject(ex);
+        return undefined;
       }
-    });
   }
 
   addPolygon(options: AddPolygonOptions, nativeMap?): Promise<any> {


### PR DESCRIPTION
This PR contains changes in:
- addSource
- addLayer
- handling click events on the map
- queryRenderedFeatures

By changing `addSource` to support FeatureCollections the `circles` array which kept track of the added source was no longer useable. Therefor some changes needed to be made to the way click events on the map are handled.
As an added bonus this also solved the issue where line features needed to have a seperate way to handle click events (with the annotationlayer). So this seems no longer needed, although I don't know if there are any edge cases that I might miss now.
Once you click on the map all layers that are registered to the mapEvent
`this.mapboxView.onMapEvent( 'click', 'layer-id', ...` will be queried, this means that if multiple layers are on top of each other, multiple events could be triggered. 
I've added a sample of this in the demo-angular project (where a line, point and featurecollection layer are on the of each other).

Since the click events on the map don't support async functions I needed to convert `queryRenderedFeatures` from an async/promise function to a 'sync' function. Since this code was already synchronous from mapbox itself this wasn't a very big change. Also, since only the features that are already rendered on the map are being queried I don't think having this function synchronous would cause performance issues.

CircleLayers now support expressions in json format, all the paint property that were already supported now also support json expressions.
The same could probably also work for linelayers but that hasn't been implemented yet.

Still left to do: 
- addLinePoint -> this is still commented out because this relied on the lines array which is no longer available -> **Done**
- json expression support for linelayers
- I don't own any Apple devices so I'm not in the position to develop/debug/test on iOS, so that part hasn't changed

N.B.: Sorry for the whitespace changes you check it without the whitespaces by adding `?w=1` to the url