### PR TITLE
fixed deprecated 'utils.ios.getter' calls

### DIFF
--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -884,7 +884,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           this._mapboxViewInstance.removeFromSuperview();
         }
 
-        const view = utils.ios.getter( UIApplication, UIApplication.sharedApplication ).keyWindow.rootViewController.view,
+        const view = UIApplication.sharedApplication.keyWindow.rootViewController.view,
           frameRect = view.frame,
           mapFrame = CGRectMake(
             settings.margins.left,
@@ -940,7 +940,7 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
     return new Promise((resolve, reject) => {
       try {
         if ( this._mapboxViewInstance ) {
-          let view = utils.ios.getter(UIApplication, UIApplication.sharedApplication).keyWindow.rootViewController.view;
+          let view = UIApplication.sharedApplication.keyWindow.rootViewController.view;
           view.addSubview( this._mapboxViewInstance);
           resolve();
         } else {
@@ -2953,8 +2953,8 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 }
 
 const _addObserver = (eventName, callback) => {
-  return utils.ios.getter(NSNotificationCenter, NSNotificationCenter.defaultCenter).addObserverForNameObjectQueueUsingBlock(
-      eventName, null, utils.ios.getter(NSOperationQueue, NSOperationQueue.mainQueue), callback);
+  return NSNotificationCenter.defaultCenter.addObserverForNameObjectQueueUsingBlock(
+      eventName, null, NSOperationQueue.mainQueue, callback);
 };
 
 const _downloadImage = marker => {


### PR DESCRIPTION
utils.ios.getter calls are deprecated since NS 5 and removed since NS 6