### PR TITLE
Add support for featurecollections and expressions in geojson format (without ws changes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ demo/platforms
 node_modules
 demo/hooks/
 publish/package/
+publish/dist/
 ngdemo/lib
 ngdemo/platoforms
 ngdemo/node_modules

--- a/demo-angular/src/app/components/map/map.component.ts
+++ b/demo-angular/src/app/components/map/map.component.ts
@@ -270,6 +270,10 @@ export class MapComponent implements OnInit, OnDestroy {
 
     console.log( "MapComponent:onMapReady(): after declareReady()" );
 
+    this.addTestCircle();
+    this.addTestFeatureCollection();
+    this.addTestLine();
+
   } // end of onMapReady()
 
   // --------------------------------------
@@ -541,13 +545,11 @@ export class MapComponent implements OnInit, OnDestroy {
         }
       }, 
       "paint": {
-        "circle-radius": {
-          "stops": [
-            [0, 0],
-            [20, pixels ]
+        'circle-radius': [
+					"interpolate", ["exponential", 2], ["zoom"],
+					0, 0,
+					20, pixels
           ],
-          "base": 2
-        },
         'circle-opacity': 0.05,
         'circle-color': '#ed6498',
         'circle-stroke-width': 2,
@@ -561,9 +563,9 @@ export class MapComponent implements OnInit, OnDestroy {
       console.error("MapComponent:addTestCircle(): addTestCircle threw an error:", error );
     });
 
-    this.mapboxView.onMapEvent( 'click', 'testCircle', ( point ) => {
+    this.mapboxView.onMapEvent( 'click', 'testCircle', ( features ) => {
 
-      console.log( "MapComponent:addTestCircle(): circle clicked" );
+      console.log( "MapComponent:addTestCircle(): circle clicked", features);
 
       // mandatory
 
@@ -571,6 +573,163 @@ export class MapComponent implements OnInit, OnDestroy {
 
     });
 
+  }
+
+  addTestFeatureCollection() {
+    const locations = [
+      [ -76.947041, 39.007846 ],
+      [ -76.947041, 38.997846 ],
+      [ -76.947041, 38.987846 ],
+      [ -76.947041, 38.977846 ],
+      [ -76.947041, 38.967846 ],
+      [ -76.947041, 38.957846 ],
+      [ -76.947041, 38.947846 ],
+      [ -76.947041, 38.937846 ],
+      [ -76.947041, 38.927846 ],
+      [ -76.947041, 38.917846 ]
+    ]
+
+    const source: any = {
+			'type': 'geojson',
+			'data': {
+				'type': 'FeatureCollection',
+				'features': locations.map((location, i) => ({
+					'type': 'Feature',
+					'geometry': {
+						'type': 'Point',
+						'coordinates': location
+					},
+					'properties': {
+						'status': i < 4 ? 'todo' : 'done'
+					}
+				}))
+			}
+    }
+    
+    this.mapboxView.addSource('collection', source);
+    
+		this.mapboxView.addLayer({
+			'id': 'collection',
+			'type': 'circle',
+			'source': 'collection',
+			'paint': {
+				// make circles larger as the user zooms from z12 to z22
+				'circle-radius': [
+					"interpolate", ["exponential", 1], ["zoom"],
+					// zoom is 12 (or less) -> circle radius will be 5px
+					12, 5,
+					// zoom is 22 (or greater) -> circle radius will be 18px
+					22, 18
+				],
+				'circle-color': [
+					'match',
+					['get', 'status'],
+					'todo',
+					'#238E6B', // green
+					'done',
+					'#2A5A8B', // blue
+					'#333' // default
+				]
+			}
+		}).catch((error) => {
+			console.error('MapComponent:onMapReady(): addLayer threw an error:', error);
+    });
+    
+    this.mapboxView.onMapEvent('click', 'collection', (features) => {
+
+			console.log('MapComponent:addTestLine(): collection clicked', features);
+
+			// mandatory
+
+			return true;
+
+		});
+  }
+
+  addTestLine() {
+    const lineFeature = {
+			"type": "FeatureCollection",
+			"features": [{
+				"type": "Feature",
+				"geometry": {
+					"type": "LineString",
+					"coordinates": [
+						[-76.947041, 39.007846],
+						[12.5, 41.9]
+					]
+				},
+				"properties": {
+					"line-color": "white",
+					"line-width": "8",
+					"is-draggable": false
+				}
+			}]
+		}
+
+    // Track near the Golden Gate Bridge
+		const lineFeature2 = {
+			'type': 'Feature',
+			'properties': {},
+			'geometry': {
+				'type': 'LineString',
+				'coordinates': [
+					[-122.48369693756104, 37.83381888486939],
+					[-122.48348236083984, 37.83317489144141],
+					[-122.48339653015138, 37.83270036637107],
+					[-122.48356819152832, 37.832056363179625],
+					[-122.48404026031496, 37.83114119107971],
+					[-122.48404026031496, 37.83049717427869],
+					[-122.48348236083984, 37.829920943955045],
+					[-122.48356819152832, 37.82954808664175],
+					[-122.48507022857666, 37.82944639795659],
+					[-122.48610019683838, 37.82880236636284],
+					[-122.48695850372314, 37.82931081282506],
+					[-122.48700141906738, 37.83080223556934],
+					[-122.48751640319824, 37.83168351665737],
+					[-122.48803138732912, 37.832158048267786],
+					[-122.48888969421387, 37.83297152392784],
+					[-122.48987674713133, 37.83263257682617],
+					[-122.49043464660643, 37.832937629287755],
+					[-122.49125003814696, 37.832429207817725],
+					[-122.49163627624512, 37.832564787218985],
+					[-122.49223709106445, 37.83337825839438],
+					[-122.49378204345702, 37.83368330777276]
+				]
+			}
+		}
+
+
+		this.mapboxView.addSource('route', {
+      'type': 'geojson',
+      'url': undefined,
+			'data': lineFeature
+    });
+    
+		this.mapboxView.addLayer({
+			'id': 'route',
+			'type': 'line',
+			'source': 'route',
+			'layout': {
+				'line-join': 'round',
+				'line-cap': 'round'
+			},
+			'paint': {
+				'line-color': '#888',
+				'line-width': 8
+			}
+		}).catch((error) => {
+			console.error('MapComponent:onMapReady(): addLayer threw an error:', error);
+		});
+
+		this.mapboxView.onMapEvent('click', 'route', (features) => {
+
+			console.log('MapComponent:addTestLine(): line clicked', features);
+
+			// mandatory
+
+			return true;
+
+		});
   }
 
 } // end of mapComponent

--- a/demo/app/main-page.ts
+++ b/demo/app/main-page.ts
@@ -113,12 +113,14 @@ export function onMapReady(args) {
   ).then(() => {
     console.log("main-page Markers added");
     setTimeout(() => {
-      map.queryRenderedFeatures({
+      const result = map.queryRenderedFeatures({
         point: {
           lat: 52.3602160,
           lng: 4.8891680
         }
-      }).then(result => console.log(JSON.stringify(result)));
+      });
+
+      console.log(JSON.stringify(result));
     }, 1000);
   }).catch( ( error ) => {
     console.error( "main-page: error adding markers:", error );

--- a/src/mapbox.common.ts
+++ b/src/mapbox.common.ts
@@ -568,7 +568,7 @@ export interface MapboxApi {
 
   addLinePoint( id : string, point, nativeMapView? : any ): Promise<any>;
 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions, nativeMap?: any): Promise<Array<Feature>>;
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions, nativeMap?: any): Array<Feature>;
 
   addPolygon(options: AddPolygonOptions, nativeMap?: any): Promise<any>;
 
@@ -580,7 +580,7 @@ export interface MapboxApi {
 
   animateCamera(options: AnimateCameraOptions, nativeMap?: any): Promise<any>;
 
-  setOnMapClickListener(listener: (data: LatLng) => void, nativeMap?): Promise<any>;
+  setOnMapClickListener(listener: (data: LatLng) => boolean, nativeMap?): Promise<any>;
 
   setOnMapLongClickListener(listener: (data: LatLng) => void, nativeMap?): Promise<any>;
 
@@ -697,9 +697,9 @@ export interface MapboxViewApi {
 
   removeMarkers(options?: any): Promise<any>;
 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Promise<Array<Feature>>;
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Array<Feature>;
 
-  setOnMapClickListener(listener: (data: LatLng) => void): Promise<any>;
+  setOnMapClickListener(listener: (data: LatLng) => boolean): Promise<any>;
 
   setOnMapLongClickListener(listener: (data: LatLng) => void): Promise<any>;
 
@@ -755,7 +755,7 @@ export interface MapboxViewApi {
 
   addLinePoint( id : string, point ): Promise<any>;
 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Promise<Array<Feature>>;
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Array<Feature>;
 
   addPolygon(options: AddPolygonOptions): Promise<any>;
 
@@ -841,7 +841,7 @@ export abstract class MapboxViewCommonBase extends ContentView implements Mapbox
 
   // -----------------------------------------------------------------
 
-  setOnMapClickListener(listener: (data: LatLng) => void): Promise<any> {
+  setOnMapClickListener(listener: (data: LatLng) => boolean): Promise<any> {
     return this.mapbox.setOnMapClickListener(listener, this.getNativeMapView());
   }
 
@@ -1007,7 +1007,7 @@ export abstract class MapboxViewCommonBase extends ContentView implements Mapbox
 
   // -----------------------------------------------------------------
 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Promise<Array<Feature>> {
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions): Array<Feature> {
     return this.mapbox.queryRenderedFeatures(options, this.getNativeMapView());
   }
 

--- a/src/mapbox.ios.ts
+++ b/src/mapbox.ios.ts
@@ -1421,14 +1421,12 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
 
   // --------------------------------------------------------------
 
-  queryRenderedFeatures(options: QueryRenderedFeaturesOptions, nativeMap?): Promise<Array<Feature>> {
-    return new Promise((resolve, reject) => {
+  queryRenderedFeatures(options: QueryRenderedFeaturesOptions, nativeMap?): Array<Feature> {
       try {
         const theMap: MGLMapView = nativeMap || this._mapboxViewInstance;
         const point = options.point;
         if (point === undefined) {
-          reject("Please set the 'point' parameter");
-          return;
+          throw new Error("Please set the 'point' parameter");
         }
 
         const {x, y} = theMap.convertCoordinateToPointToView({latitude: point.lat, longitude: point.lng}, theMap);
@@ -1457,12 +1455,11 @@ export class Mapbox extends MapboxCommon implements MapboxApi {
           });
         }
 
-        resolve(result);
+        return result;
       } catch (ex) {
         console.log("Error in mapbox.queryRenderedFeatures: " + ex);
-        reject(ex);
+        return undefined;
       }
-    });
   }
 
   addPolygon(options: AddPolygonOptions, nativeMap?): Promise<any> {


### PR DESCRIPTION
This PR contains changes in:

addSource
addLayer
handling click events on the map
queryRenderedFeatures
By changing addSource to support FeatureCollections the circles array which kept track of the added source was no longer useable. Therefor some changes needed to be made to the way click events on the map are handled.
As an added bonus this also solved the issue where line features needed to have a seperate way to handle click events (with the annotationlayer). So this seems no longer needed, although I don't know if there are any edge cases that I might miss now.
Once you click on the map all layers that are registered to the mapEvent
this.mapboxView.onMapEvent( 'click', 'layer-id', ... will be queried, this means that if multiple layers are on top of each other, multiple events could be triggered.
I've added a sample of this in the demo-angular project (where a line, point and featurecollection layer are on the of each other).

Since the click events on the map don't support async functions I needed to convert queryRenderedFeatures from an async/promise function to a 'sync' function. Since this code was already synchronous from mapbox itself this wasn't a very big change. Also, since only the features that are already rendered on the map are being queried I don't think having this function synchronous would cause performance issues.

CircleLayers now support expressions in json format, all the paint property that were already supported now also support json expressions.
The same could probably also work for linelayers but that hasn't been implemented yet.

Still left to do:
- addLinePoint -> this is still commented out because this relied on the lines array which is no longer available -> Done
- json expression support for linelayers
- I don't own any Apple devices so I'm not in the position to develop/debug/test on iOS, so that part hasn't changed
